### PR TITLE
Refactor tests, classes and methods and configuration options to toggle modules.

### DIFF
--- a/app/code/local/Elite/TestCase.php
+++ b/app/code/local/Elite/TestCase.php
@@ -1,0 +1,254 @@
+<?php
+
+
+class Elite_TestCase extends VF_AbstractTestCase
+{
+
+    protected function setUp()
+    {
+        parent::setUp();
+        Elite_Vaf_Singleton::getInstance(true);
+        Elite_Vaf_Singleton::getInstance()->setRequest(new Zend_Controller_Request_Http);
+        $database = new VF_TestDbAdapter(array(
+                                              'dbname'   => VAF_DB_NAME,
+                                              'username' => VAF_DB_USERNAME,
+                                              'password' => VAF_DB_PASSWORD
+                                         ));
+        Elite_Vaf_Singleton::getInstance()->setReadAdapter($database);
+
+        VF_Schema::$levels = null;
+
+        $_SESSION = array();
+        $_GET = array();
+        $_REQUEST = array();
+        $_POST = array();
+        $_FILES = array();
+
+        $this->resetIdentityMaps();
+        $this->dropAndRecreateMockProductTable();
+
+        if (class_exists('Mage', false)) {
+            Mage::resetRegistry();
+        }
+
+        $this->doSetUp();
+    }
+
+    function getProductForSku($sku)
+    {
+        $sql = sprintf(
+            "SELECT `entity_id` from `test_catalog_product_entity` WHERE `sku` = %s",
+            $this->getReadAdapter()->quote($sku)
+        );
+        $r = $this->query($sql);
+        $product_id = $r->fetchColumn();
+        $r->closeCursor();
+
+        $product = new Elite_Vaf_Model_Catalog_Product();
+        $product->setId($product_id);
+
+        return $product;
+    }
+
+    function newProduct($id = null)
+    {
+        $product = new Elite_Vaf_Model_Catalog_Product;
+        if (!is_null($id)) {
+            $product->setId($id);
+        }
+        return $product;
+    }
+
+    function newWheelProduct($id = null)
+    {
+        $product = new Elite_Vafwheel_Model_Catalog_Product($this->newProduct($id));
+        return $product;
+    }
+
+    function newWheelAdapterProduct($id = null)
+    {
+        $product = new Elite_Vafwheeladapter_Model_Catalog_Product($this->newProduct($id));
+        return $product;
+    }
+
+    function newTireProduct($id = null, $tireSize = null, $tireType = null)
+    {
+        $tireProduct = new Elite_Vaftire_Model_Catalog_Product($this->newProduct($id));
+        if (!is_null($tireSize)) {
+            $tireProduct->setTireSize($tireSize);
+        }
+        if (!is_null($tireType)) {
+            $tireProduct->setTireType($tireType);
+        }
+        return $tireProduct;
+    }
+
+    /** @return Elite_Vaftire_Model_FlexibleSearch */
+    function flexibleTireSearch($requestParams = array())
+    {
+        $this->setRequestParams($requestParams);
+
+        $flexibleSearch = new VF_FlexibleSearch(new VF_Schema(), $this->getRequest($requestParams));
+        $tireFlexibleSearch = new Elite_Vaftire_Model_FlexibleSearch($flexibleSearch);
+        return $tireFlexibleSearch;
+    }
+
+    /** @return Elite_Vafwheeladapter_Model_FlexibleSearch */
+    function flexibleWheeladapterSearch($requestParams = array())
+    {
+        $this->setRequestParams($requestParams);
+
+        $flexibleSearch = new VF_FlexibleSearch(new VF_Schema(), $this->getRequest($requestParams));
+        $tireFlexibleSearch = new Elite_Vafwheeladapter_Model_FlexibleSearch($flexibleSearch);
+        return $tireFlexibleSearch;
+    }
+
+    function flexibleWheelSearch($requestParams = array())
+    {
+        if (count($requestParams)) {
+            $this->setRequestParams($requestParams);
+            $request = $this->getRequest($requestParams);
+        } else {
+            $request = Elite_Vaf_Singleton::getInstance()->getRequest();
+        }
+
+        $flexibleSearch = new VF_FlexibleSearch(new VF_Schema(), $request);
+        $flexibleSearch = new Elite_Vafwheel_Model_FlexibleSearch($flexibleSearch);
+        return $flexibleSearch;
+    }
+
+    function merge($slaveLevels, $masterLevel)
+    {
+        $merge = new Elite_Vaf_Model_Merge($slaveLevels, $masterLevel);
+        $merge->execute();
+    }
+
+    function split($vehicle, $grain, $newTitles)
+    {
+        $split = new Elite_Vaf_Model_Split($vehicle, $grain, $newTitles);
+        $split->execute();
+    }
+
+    function boltPattern($boltPatternString, $offset = null)
+    {
+        return Elite_Vafwheel_Model_BoltPattern::create($boltPatternString, $offset);
+    }
+
+    function wheelAdapterFinder()
+    {
+        return new Elite_Vafwheeladapter_Model_Finder;
+    }
+
+    function tireFinder()
+    {
+        return new Elite_Vaftire_Model_Finder;
+    }
+
+    function definitionsController($request = null)
+    {
+        if (is_null($request)) {
+            $request = new Zend_Controller_Request_Http();
+        }
+        require_once(ELITE_PATH . '/Vaf/controllers/Admin/VehicleslistController.php');
+        require_once(ELITE_PATH . '/Vaf/controllers/Admin/DefinitionsController/TestSubClass.php');
+        $controller
+            = new Elite_Vaf_Admin_DefinitionsController_TestSubClass($request, new Zend_Controller_Response_Http());
+        return $controller;
+    }
+
+    function createTireMMY($make, $model, $year)
+    {
+        $vehicle = $this->createMMY($make, $model, $year);
+        return new Elite_Vaftire_Model_Vehicle($vehicle);
+    }
+
+    protected function setRequest(Zend_Controller_Request_Abstract $request)
+    {
+        Elite_Vaf_Singleton::getInstance()->setRequest($request);
+    }
+
+    /** @return Zend_Db_Adapter_Abstract */
+    protected function getReadAdapter()
+    {
+        return Elite_Vaf_Singleton::getInstance()->getReadAdapter();
+    }
+
+    protected function getHelper($config = array(), $requestParams = array())
+    {
+        $request = $this->getRequest($requestParams);
+        $helper = Elite_Vaf_Singleton::getInstance();
+        $helper->setRequest($request);
+        if (count($config)) {
+            $helper->setConfig(new Zend_Config($config, true));
+        }
+        return $helper;
+    }
+
+    protected function request($controllerName = '', $routeName = '', $uri = false)
+    {
+        if ($uri) {
+            $request = $this->getMock(
+                'Mage_Core_Controller_Request_Http',
+                array('getControllerName', 'getRouteName'),
+                array($uri),
+                '',
+                true,
+                false
+            );
+        } else {
+            $request = $this->getMock(
+                'Mage_Core_Controller_Request_Http',
+                array('getControllerName', 'getRouteName'),
+                array(),
+                '',
+                false,
+                false
+            );
+        }
+        $request->expects($this->any())->method('getControllerName')->will($this->returnValue($controllerName));
+        $request->expects($this->any())->method('getRouteName')->will($this->returnValue($routeName));
+        return $request;
+    }
+
+}
+
+class Elite_Vaf_Model_TestSubClass extends VF_Level
+{
+
+    function getLevels()
+    {
+        return array('make', 'model', 'year');
+    }
+
+    function getNextLevel()
+    {
+        return '';
+    }
+
+    function getPrevLevel()
+    {
+        return '';
+    }
+
+    function getLeafLevel()
+    {
+        return 'year';
+    }
+
+    function createEntity($level, $id = 0)
+    {
+        switch ($level) {
+            case 'make':
+                return new Elite_Vaf_Model_TestSubClass_Make($level, $id);
+                break;
+            case 'model':
+                return new Elite_Vaf_Model_TestSubClass_Model($level, $id);
+                break;
+            case 'year':
+                return new Elite_Vaf_Model_TestSubClass_Year($level, $id);
+                break;
+        }
+        return new VF_Level($level, $id);
+    }
+
+}

--- a/app/code/local/Elite/Vaf/Adminhtml/Block/Catalog/Product/Edit/Tab/Vaf.php
+++ b/app/code/local/Elite/Vaf/Adminhtml/Block/Catalog/Product/Edit/Tab/Vaf.php
@@ -88,7 +88,7 @@ class Elite_Vaf_Adminhtml_Block_Catalog_Product_Edit_Tab_Vaf extends Mage_Adminh
     {
         if( !$this->config instanceof Zend_Config )
         {
-            $this->config = VF_Singleton::getInstance()->getConfig();
+            $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
         }
         return $this->config;
     }

--- a/app/code/local/Elite/Vaf/Adminhtml/Block/Definitions.php
+++ b/app/code/local/Elite/Vaf/Adminhtml/Block/Definitions.php
@@ -38,7 +38,7 @@ class Elite_Vaf_Adminhtml_Block_Definitions extends Elite_Vaf_Block_Abstract imp
         if( !$this->config instanceof Zend_Config )
         {
             
-            $this->config = VF_Singleton::getInstance()->getConfig();
+            $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
         }    
         return $this->config;
     }

--- a/app/code/local/Elite/Vaf/Adminhtml/Block/Schema.php
+++ b/app/code/local/Elite/Vaf/Adminhtml/Block/Schema.php
@@ -31,7 +31,7 @@ class Elite_Vaf_Adminhtml_Block_Schema extends Elite_Vaf_Block_Abstract implemen
     {
         if( !$this->config instanceof Zend_Config )
         {
-            $this->config = VF_Singleton::getInstance()->getConfig();
+            $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
         }    
         return $this->config;
     }

--- a/app/code/local/Elite/Vaf/Block/Abstract.php
+++ b/app/code/local/Elite/Vaf/Block/Abstract.php
@@ -31,7 +31,7 @@ abstract class Elite_Vaf_Block_Abstract extends Mage_Core_Block_Template
     {
         if( !$this->config instanceof Zend_Config )
         {
-            $this->config = VF_Singleton::getInstance()->getConfig();
+            $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
         }
         return $this->config;
     }

--- a/app/code/local/Elite/Vaf/Block/Category/View.php
+++ b/app/code/local/Elite/Vaf/Block/Category/View.php
@@ -98,7 +98,7 @@ class Elite_Vaf_Block_Category_View extends Mage_Catalog_Block_Category_View
     /** @return boolean */
     function vehicleIsSelected()
     {
-        return !VF_Singleton::getInstance()->vehicleSelection()->isEmpty();
+        return !Elite_Vaf_Singleton::getInstance()->vehicleSelection()->isEmpty();
     }
     
     function setConfig($config)
@@ -110,7 +110,7 @@ class Elite_Vaf_Block_Category_View extends Mage_Catalog_Block_Category_View
     {
         if( !$this->config instanceof Zend_Config )
         {
-            $this->config = VF_Singleton::getInstance()->getConfig();
+            $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
         }    
         return $this->config;
     }

--- a/app/code/local/Elite/Vaf/Block/Category/ViewSplashTest.php
+++ b/app/code/local/Elite/Vaf/Block/Category/ViewSplashTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Block_Category_ViewSplashTest extends VF_TestCase
+class Elite_Vaf_Block_Category_ViewSplashTest extends Elite_TestCase
 {
     function doSetUp()
     {

--- a/app/code/local/Elite/Vaf/Block/Product/Result.php
+++ b/app/code/local/Elite/Vaf/Block/Product/Result.php
@@ -41,7 +41,7 @@ class Elite_Vaf_Block_Product_Result extends Elite_Vaf_Block_Product_List
 
     function getHeaderText()
     {
-        $fit = VF_Singleton::getInstance()->vehicleSelection();
+        $fit = Elite_Vaf_Singleton::getInstance()->vehicleSelection();
         if( $fit )
         {            
             return $this->translate("Products for %s", htmlentities( $fit->__toString() ) );
@@ -155,7 +155,7 @@ class Elite_Vaf_Block_Product_Result extends Elite_Vaf_Block_Product_List
     function productCategoryHashMap($ids)
     {
         // get product ID <-> category ID array
-        $select = VF_Singleton::getInstance()->getReadAdapter()
+        $select = Elite_Vaf_Singleton::getInstance()->getReadAdapter()
                     ->select()
                     ->from('catalog_category_product_index', array('category_id','product_id'))
                     ->where('product_id IN (' . implode(',',$ids) .')')
@@ -202,7 +202,7 @@ class Elite_Vaf_Block_Product_Result extends Elite_Vaf_Block_Product_List
     
     protected function getExcludeCategories()
     {
-        $exclude = explode( ',', VF_Singleton::getInstance()->getConfig()->homepagesearch->exclude_categories );
+        $exclude = explode( ',', Elite_Vaf_Singleton::getInstance()->getConfig()->homepagesearch->exclude_categories );
         return $exclude;
     }
     

--- a/app/code/local/Elite/Vaf/Block/Product/ResultTest.php
+++ b/app/code/local/Elite/Vaf/Block/Product/ResultTest.php
@@ -21,8 +21,11 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Block_Product_ResultTest extends VF_SearchTestCase
+class Elite_Vaf_Block_Product_ResultTest extends Elite_Vaf_Block_SearchTestCase
 {
+    protected function setUp() {
+        parent::setUp();
+    }
     function testShouldTranslate()
     {
         $vehicle = $this->createVehicle(array('make'=>'Honda','model'=>'Civic','year'=>2000));

--- a/app/code/local/Elite/Vaf/Block/Search.php
+++ b/app/code/local/Elite/Vaf/Block/Search.php
@@ -145,7 +145,7 @@ class VF_Search_Mage extends VF_Search
         {
             return $this->_request;
         }
-        $this->_request = VF_Singleton::getInstance()->getRequest();
+        $this->_request = Elite_Vaf_Singleton::getInstance()->getRequest();
         return $this->_request;
     }
 

--- a/app/code/local/Elite/Vaf/Block/Search/CategoryChooser.php
+++ b/app/code/local/Elite/Vaf/Block/Search/CategoryChooser.php
@@ -38,7 +38,7 @@ class Elite_Vaf_Block_Search_CategoryChooser implements VF_Configurable
         if( !$this->config instanceof Zend_Config )
         {
             
-            $this->config = VF_Singleton::getInstance()->getConfig();
+            $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
         }    
         return $this->config;
     }

--- a/app/code/local/Elite/Vaf/Block/Search/ChoosevehicleTest.php
+++ b/app/code/local/Elite/Vaf/Block/Search/ChoosevehicleTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Block_Search_ChoosevehicleTest extends VF_SearchTestCase
+class Elite_Vaf_Block_Search_ChoosevehicleTest extends Elite_Vaf_Block_SearchTestCase
 {
     function testDoesntShowCategoryChooser()
     {

--- a/app/code/local/Elite/Vaf/Block/SearchTestCase.php
+++ b/app/code/local/Elite/Vaf/Block/SearchTestCase.php
@@ -1,0 +1,51 @@
+<?php
+
+
+class Elite_Vaf_Block_SearchTestCase extends Elite_TestCase
+{
+    protected function getBlockWithChooserConfig($configArray)
+    {
+        return $this->getBlock(array('categorychooser' => $configArray));
+    }
+
+    protected function getBlockWithSearchConfig($configArray)
+    {
+        return $this->getBlock(array('search' => $configArray));
+    }
+
+    protected function getBlock($configArray = null, $requestParams = array())
+    {
+        $search = $this->doGetBlock();
+        if (is_array($configArray)) {
+            $search->setConfig(new Zend_Config($configArray));
+        }
+        $search->setRequest($this->getRequest($requestParams));
+        return $search;
+    }
+
+    protected function doGetBlock()
+    {
+        return new Elite_Vaf_Block_Search();
+    }
+
+    function getMagentoRequest($params = array())
+    {
+        $request = $this->getMock('Mage_Core_Controller_Request_Http', array(), array(), '', false);
+        foreach ($params as $key => $val) {
+            $cmd = 'get' . ucfirst($key);
+            $request->expects($this->any())->method($cmd)->will($this->returnValue($val));
+        }
+        return $request;
+    }
+
+    // @todo curently if it is anything but product & catalog, for the controller & route name, it detects it as homepage
+    protected function emulateHomepage($search)
+    {
+        $search->setRequest($this->getMagentoRequest(array('controllerName' => 'index', 'routeName' => 'cms')));
+    }
+
+    protected function emulateNotHomepage($search)
+    {
+        $search->setRequest($this->getMagentoRequest(array('controllerName' => 'category', 'routeName' => 'catalog')));
+    }
+}

--- a/app/code/local/Elite/Vaf/Block/SearchTests/CategoryChooser/AllOptionTest.php
+++ b/app/code/local/Elite/Vaf/Block/SearchTests/CategoryChooser/AllOptionTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Block_SearchTests_CategoryChooser_AllOptionTest extends VF_SearchTestCase
+class Elite_Vaf_Block_SearchTests_CategoryChooser_AllOptionTest extends Elite_Vaf_Block_SearchTestCase
 {
     /**
     * Tests for wether All Option shows when it IS the homepage

--- a/app/code/local/Elite/Vaf/Block/SearchTests/CategoryChooser/CategoryChooserTest.php
+++ b/app/code/local/Elite/Vaf/Block/SearchTests/CategoryChooser/CategoryChooserTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Block_SearchTests_CategoryChooser_CategoryChooserTest extends VF_SearchTestCase
+class Elite_Vaf_Block_SearchTests_CategoryChooser_CategoryChooserTest extends Elite_Vaf_Block_SearchTestCase
 {
     /**
     * Tests for wether Search shows When it IS the homempage

--- a/app/code/local/Elite/Vaf/Block/SearchTests/CategoryChooser/IgnoreCategoryTest.php
+++ b/app/code/local/Elite/Vaf/Block/SearchTests/CategoryChooser/IgnoreCategoryTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Block_SearchTests_CategoryChooser_IgnoreCategoryTest extends VF_SearchTestCase
+class Elite_Vaf_Block_SearchTests_CategoryChooser_IgnoreCategoryTest extends Elite_Vaf_Block_SearchTestCase
 {
     
     function testWhenCategoriesBlacklistedItFilters()

--- a/app/code/local/Elite/Vaf/Block/SearchTests/Search/ClearButtonTest.php
+++ b/app/code/local/Elite/Vaf/Block/SearchTests/Search/ClearButtonTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Block_SearchTests_Search_ClearButtonTest extends VF_SearchTestCase
+class Elite_Vaf_Block_SearchTests_Search_ClearButtonTest extends Elite_Vaf_Block_SearchTestCase
 {
     
     // visibility   

--- a/app/code/local/Elite/Vaf/Block/SearchTests/Search/SubmitActionPerCategoryTest.php
+++ b/app/code/local/Elite/Vaf/Block/SearchTests/Search/SubmitActionPerCategoryTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Block_SearchTests_Search_SubmitActionPerCategoryTest extends VF_TestCase
+class Elite_Vaf_Block_SearchTests_Search_SubmitActionPerCategoryTest extends Elite_TestCase
 {
     const HomePageSearch = 'vaf/product/list';
 

--- a/app/code/local/Elite/Vaf/Block/SearchTests/Search/SubmitActionTest.php
+++ b/app/code/local/Elite/Vaf/Block/SearchTests/Search/SubmitActionTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Block_SearchTests_Search_SubmitActionTest extends VF_TestCase
+class Elite_Vaf_Block_SearchTests_Search_SubmitActionTest extends Elite_TestCase
 {
     const HomePageSearch = 'vaf/product/list';
     

--- a/app/code/local/Elite/Vaf/Block/SearchTests/Search/SubmitButtonTest.php
+++ b/app/code/local/Elite/Vaf/Block/SearchTests/Search/SubmitButtonTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Block_SearchTests_Search_SubmitButtonTest extends VF_SearchTestCase
+class Elite_Vaf_Block_SearchTests_Search_SubmitButtonTest extends Elite_Vaf_Block_SearchTestCase
 {
     
     // visibility   

--- a/app/code/local/Elite/Vaf/Block/SearchTests/Search/TranslateTest.php
+++ b/app/code/local/Elite/Vaf/Block/SearchTests/Search/TranslateTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Block_SearchTests_Search_TranslateTest extends VF_SearchTestCase
+class Elite_Vaf_Block_SearchTests_Search_TranslateTest extends Elite_Vaf_Block_SearchTestCase
 {
     function testShouldTranslate()
     {

--- a/app/code/local/Elite/Vaf/Block/SearchTests/Search/WhiteBlackListTest.php
+++ b/app/code/local/Elite/Vaf/Block/SearchTests/Search/WhiteBlackListTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Block_SearchTests_Search_WhiteBlackListTest extends VF_SearchTestCase
+class Elite_Vaf_Block_SearchTests_Search_WhiteBlackListTest extends Elite_Vaf_Block_SearchTestCase
 {
     
     const ID = 3;

--- a/app/code/local/Elite/Vaf/ConfigTest.php
+++ b/app/code/local/Elite/Vaf/ConfigTest.php
@@ -20,7 +20,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class VF_SingletonTest_ConfigTest extends VF_TestCase
+class Elite_Vaf_SingletonTest_ConfigTest extends Elite_TestCase
 {
     function testShouldHaveVfdataSection()
     {

--- a/app/code/local/Elite/Vaf/MockController.php
+++ b/app/code/local/Elite/Vaf/MockController.php
@@ -25,6 +25,6 @@ class Elite_Vaf_MockController
 {
     function getRequest()
     {
-        return VF_Singleton::getInstance()->getRequest();
+        return Elite_Vaf_Singleton::getInstance()->getRequest();
     }
 }

--- a/app/code/local/Elite/Vaf/Model/Base.php
+++ b/app/code/local/Elite/Vaf/Model/Base.php
@@ -70,7 +70,7 @@ abstract class Elite_Vaf_Model_Base
         if( !$this->config instanceof Zend_Config )
         {
             
-            $this->config = VF_Singleton::getInstance()->getConfig();
+            $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
         }    
         return $this->config;
     }
@@ -83,6 +83,6 @@ abstract class Elite_Vaf_Model_Base
     /** @return Zend_Db_Adapter_Abstract */
     protected function getReadAdapter()
     {
-        return VF_Singleton::getInstance()->getReadAdapter();
+        return Elite_Vaf_Singleton::getInstance()->getReadAdapter();
     }
 }

--- a/app/code/local/Elite/Vaf/Model/Catalog/Category.php
+++ b/app/code/local/Elite/Vaf/Model/Catalog/Category.php
@@ -42,7 +42,7 @@ class Elite_Vaf_Model_Catalog_Category extends Mage_Catalog_Model_Category imple
     {
         if( !$this->config instanceof Zend_Config )
         {
-            $this->config = VF_Singleton::getInstance()->getConfig();
+            $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
         }    
         return $this->config;
     }
@@ -93,7 +93,7 @@ class Elite_Vaf_Model_Catalog_Category extends Mage_Catalog_Model_Category imple
     
     protected function getProductIdsInFilter()
     {
-        return VF_Singleton::getInstance()->getProductIds();
+        return Elite_Vaf_Singleton::getInstance()->getProductIds();
     }
     
 }

--- a/app/code/local/Elite/Vaf/Model/Catalog/Category/FilterImpl.php
+++ b/app/code/local/Elite/Vaf/Model/Catalog/Category/FilterImpl.php
@@ -35,7 +35,7 @@ class Elite_Vaf_Model_Catalog_Category_FilterImpl implements
         if( !$this->config instanceof Zend_Config )
         {
             
-            $this->config = VF_Singleton::getInstance()->getConfig();
+            $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
         }    
         return $this->config;
     }

--- a/app/code/local/Elite/Vaf/Model/Catalog/Category/FilterTest.php
+++ b/app/code/local/Elite/Vaf/Model/Catalog/Category/FilterTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Model_Catalog_Category_FilterImplTest extends VF_TestCase
+class Elite_Vaf_Model_Catalog_Category_FilterImplTest extends Elite_TestCase
 {
     const ID = 3;
     const DIFFERENT_ID = 4;

--- a/app/code/local/Elite/Vaf/Model/Catalog/CategoryTests/CategoryTest.php
+++ b/app/code/local/Elite/Vaf/Model/Catalog/CategoryTests/CategoryTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Model_Catalog_CategoryTests_CategoryTest extends VF_TestCase
+class Elite_Vaf_Model_Catalog_CategoryTests_CategoryTest extends Elite_TestCase
 {
     function doSetUp()
     {

--- a/app/code/local/Elite/Vaf/Model/Catalog/CategoryTests/TestCase.php
+++ b/app/code/local/Elite/Vaf/Model/Catalog/CategoryTests/TestCase.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-abstract class Elite_Vaf_Model_Catalog_CategoryTests_TestCase extends VF_TestCase
+abstract class Elite_Vaf_Model_Catalog_CategoryTests_TestCase extends Elite_TestCase
 {
     const PRODUCT_ID = 5;
     
@@ -44,7 +44,7 @@ abstract class Elite_Vaf_Model_Catalog_CategoryTests_TestCase extends VF_TestCas
     {
         $vehicle = $this->createMMY();
         $this->insertMappingMMY( $vehicle, self::PRODUCT_ID );
-        VF_Singleton::getInstance()->getRequest()
+        Elite_Vaf_Singleton::getInstance()->getRequest()
             ->setParam('make',$vehicle->getLevel('make')->getId())
             ->setParam('model',$vehicle->getLevel('model')->getId())
             ->setParam('year',$vehicle->getLevel('year')->getId());

--- a/app/code/local/Elite/Vaf/Model/Catalog/ProductTests/ApplicationFitmentsTests/RewriteTitleTest.php
+++ b/app/code/local/Elite/Vaf/Model/Catalog/ProductTests/ApplicationFitmentsTests/RewriteTitleTest.php
@@ -51,7 +51,7 @@ class Elite_Vaf_Model_Catalog_ProductTests_ApplicationFitmentsTests_RewriteTitle
         $product->addVafFit($this->vehicle->toValueArray());
         
         $this->setRequestParams($this->vehicle->toValueArray());
-        $product->setCurrentlySelectedFit( VF_Singleton::getInstance()->vehicleSelection() );
+        $product->setCurrentlySelectedFit( Elite_Vaf_Singleton::getInstance()->vehicleSelection() );
         $this->assertEquals( 'Widget for Honda Civic 2002', $product->getName(), 'when product fits selection (and rewrites enabled), should rewrite title' );
     }
     
@@ -70,7 +70,7 @@ class Elite_Vaf_Model_Catalog_ProductTests_ApplicationFitmentsTests_RewriteTitle
         $product = $this->getProduct2($config);
         
         $this->setRequestParams($this->vehicle->toValueArray());
-        $product->setCurrentlySelectedFit( VF_Singleton::getInstance()->vehicleSelection() );
+        $product->setCurrentlySelectedFit( Elite_Vaf_Singleton::getInstance()->vehicleSelection() );
         $this->assertEquals( 'Widget', $product->getName(), 'when product does not fit selection, should not rewrite title' );
     }
     
@@ -96,7 +96,7 @@ class Elite_Vaf_Model_Catalog_ProductTests_ApplicationFitmentsTests_RewriteTitle
         $product->addVafFit($this->vehicle->toValueArray());
         
         $this->setRequestParams($this->vehicle->toValueArray());
-        $product->setCurrentlySelectedFit( VF_Singleton::getInstance()->vehicleSelection() );
+        $product->setCurrentlySelectedFit( Elite_Vaf_Singleton::getInstance()->vehicleSelection() );
         $this->assertEquals( 'Widget', $product->getName(), 'when rewrites disabled, should not rewrite title' );
     }
     

--- a/app/code/local/Elite/Vaf/Model/Catalog/ProductTests/FitsSelectionTest.php
+++ b/app/code/local/Elite/Vaf/Model/Catalog/ProductTests/FitsSelectionTest.php
@@ -62,6 +62,6 @@ class Elite_Vaf_Model_Catalog_ProductTests_FitsSelectionTest extends Elite_Vaf_M
 
     function setSelectedFit($vehicle)
     {
-        VF_Singleton::getInstance()->getRequest()->setParams($vehicle->toValueArray());
+        Elite_Vaf_Singleton::getInstance()->getRequest()->setParams($vehicle->toValueArray());
     }
 }

--- a/app/code/local/Elite/Vaf/Model/Catalog/ProductTests/ImportSubClassTestCase.php
+++ b/app/code/local/Elite/Vaf/Model/Catalog/ProductTests/ImportSubClassTestCase.php
@@ -1,0 +1,8 @@
+<?php
+
+
+class Elite_Vaf_Model_Catalog_ProductTests_ImportSubClassTestCase
+    extends VF_Import_ProductFitments_CSV_ImportTests_TestCase
+{
+
+}

--- a/app/code/local/Elite/Vaf/Model/Catalog/ProductTests/PriceChangerTest.php
+++ b/app/code/local/Elite/Vaf/Model/Catalog/ProductTests/PriceChangerTest.php
@@ -21,16 +21,24 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Model_Catalog_ProductTests_PriceChangerTest extends VF_Import_ProductFitments_CSV_ImportTests_TestCase
+class Elite_Vaf_Model_Catalog_ProductTests_PriceChangerTest extends Elite_TestCase
 {
+    /** @var  Elite_Vaf_Model_Catalog_ProductTests_ImportSubClassTestCase */
+    protected $importSubClass;
+
+    protected function setUp() {
+        parent::setUp();
+        $this->importSubClass = new Elite_Vaf_Model_Catalog_ProductTests_ImportSubClassTestCase();
+    }
+
     function testShouldNotChangePrice()
     {
 	$this->insertProduct('sku');
 
-	$this->mappingsImport('sku, make, model, year, price
+	$this->importSubClass->mappingsImport('sku, make, model, year, price
 sku, honda, civic, 2000, 222.22
 sku, honda, civic, 2001');
-        
+
 	$product = $this->getProductForSku('sku');
         $product->setPrice(1);
         $vehicle1 = $this->vehicleFinder()->findOneByLevels(array('make'=>'honda', 'model'=>'civic', 'year'=>2000));
@@ -45,7 +53,7 @@ sku, honda, civic, 2001');
     {
 	$this->insertProduct('sku');
 
-	$this->mappingsImport('sku, make, model, year, price
+	$this->importSubClass->mappingsImport('sku, make, model, year, price
 sku, honda, civic, 2000, 222.22
 sku, honda, civic, 2001');
 
@@ -58,7 +66,7 @@ sku, honda, civic, 2001');
     {
 	$this->insertProduct('sku');
 
-	$this->mappingsImport('sku, make, model, year, price
+	$this->importSubClass->mappingsImport('sku, make, model, year, price
 sku, honda, civic, 2000, 222.22');
 
 	$product = $this->getProductForSku('sku');
@@ -71,7 +79,7 @@ sku, honda, civic, 2000, 222.22');
     {
 	$this->insertProduct('sku');
 
-	$this->mappingsImport('sku, make, model, year, price
+	$this->importSubClass->mappingsImport('sku, make, model, year, price
 sku, honda, civic, 2000, 222.22');
 
 	$product = $this->getProductForSku('sku');
@@ -83,7 +91,7 @@ sku, honda, civic, 2000, 222.22');
     {
 	$this->insertProduct('sku');
 
-	$this->mappingsImport('sku, make, model, year, price
+	$this->importSubClass->mappingsImport('sku, make, model, year, price
 sku, honda, civic, 2000, 222.22');
 
 	$product = $this->getProductForSku('sku');
@@ -94,7 +102,7 @@ sku, honda, civic, 2000, 222.22');
     {
 	$this->insertProduct('sku');
 
-	$this->mappingsImport('sku, make, model, year, price
+	$this->importSubClass->mappingsImport('sku, make, model, year, price
 sku, honda, civic, 2000, 222.22');
 
 	$product = $this->getProductForSku('sku');
@@ -106,7 +114,7 @@ sku, honda, civic, 2000, 222.22');
     {
 	$this->insertProduct('sku');
 
-	$this->mappingsImport('sku, make, model, year, price
+	$this->importSubClass->mappingsImport('sku, make, model, year, price
 sku, honda, civic, 2000, 0');
 
 	$product = $this->getProductForSku('sku');
@@ -119,7 +127,7 @@ sku, honda, civic, 2000, 0');
     {
 	$this->insertProduct('sku');
 
-	$this->mappingsImport('sku, make, model, year, price
+	$this->importSubClass->mappingsImport('sku, make, model, year, price
 sku, honda, civic, 2000, 222.22');
 
 	$product = $this->getProductForSku('sku');
@@ -130,7 +138,7 @@ sku, honda, civic, 2000, 222.22');
     {
 	$this->insertProduct('sku');
 
-	$this->mappingsImport('price,sku, make, model, year,
+	$this->importSubClass->mappingsImport('price,sku, make, model, year,
 222.22,sku, honda, civic, 2000');
 
 	$product = $this->getProductForSku('sku');
@@ -143,7 +151,7 @@ sku, honda, civic, 2000, 222.22');
     {
 	$this->insertProduct('sku');
 
-	$this->mappingsImport('price,sku, make, model, year,
+	$this->importSubClass->mappingsImport('price,sku, make, model, year,
 222.22,sku, honda, civic, 2000');
 
 	$product = $this->getProductForSku('sku');
@@ -151,17 +159,17 @@ sku, honda, civic, 2000, 222.22');
 	$this->assertEquals( 222.22, $product->getFormatedPrice(), 'should change "formatted price"');
 
     }
-    
+
     function testGetsGlobalVehicle()
     {
         $this->insertProduct('sku');
         $vehicle = $this->createVehicle(array('make'=>'honda', 'model'=>'civic', 'year'=>2000));
-	$this->mappingsImport('price,sku, make, model, year,
+	$this->importSubClass->mappingsImport('price,sku, make, model, year,
 222.22,sku, honda, civic, 2000');
 
 	$product = $this->getProductForSku('sku');
 	$this->setRequestParams($vehicle->toValueArray());
-        
+
         $this->assertNotEquals(null,$product->currentlySelectedFit());
 	$this->assertEquals( 222.22, $product->getPrice(), 'should get price/fitment from global fitment"');
     }
@@ -170,7 +178,7 @@ sku, honda, civic, 2000, 222.22');
     {
         $this->insertProduct('sku');
         $vehicle = $this->createVehicle(array('make' => 'honda', 'model' => 'civic', 'year' => 2000));
-        $this->mappingsImport(
+        $this->importSubClass->mappingsImport(
             'price,sku, make, model, year,
             0,sku, honda, civic, 2000'
         );

--- a/app/code/local/Elite/Vaf/Model/Catalog/ProductTests/TestCase.php
+++ b/app/code/local/Elite/Vaf/Model/Catalog/ProductTests/TestCase.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-abstract class Elite_Vaf_Model_Catalog_ProductTests_TestCase extends VF_TestCase
+abstract class Elite_Vaf_Model_Catalog_ProductTests_TestCase extends Elite_TestCase
 {
     const PRODUCT_ID = 1;
     const PRODUCT_NAME = 'Widget';

--- a/app/code/local/Elite/Vaf/Model/MergeTests/FitmentNotesTest.php
+++ b/app/code/local/Elite/Vaf/Model/MergeTests/FitmentNotesTest.php
@@ -22,7 +22,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Elite_Vaf_Model_MergeTests_FitmentNotesTest extends VF_TestCase
+class Elite_Vaf_Model_MergeTests_FitmentNotesTest extends Elite_TestCase
 {
 
     function doSetUp()

--- a/app/code/local/Elite/Vaf/Model/MergeTests/MMYTest.php
+++ b/app/code/local/Elite/Vaf/Model/MergeTests/MMYTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Model_MergeTests_MMYTest extends VF_TestCase
+class Elite_Vaf_Model_MergeTests_MMYTest extends Elite_TestCase
 {
     function doSetUp()
     {

--- a/app/code/local/Elite/Vaf/Model/MergeTests/PaintTest.php
+++ b/app/code/local/Elite/Vaf/Model/MergeTests/PaintTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Model_MergeTests_PaintTest extends VF_TestCase
+class Elite_Vaf_Model_MergeTests_PaintTest extends Elite_TestCase
 {
     const NEWLINE = "\n";
     

--- a/app/code/local/Elite/Vaf/Model/MergeTests/TireTest.php
+++ b/app/code/local/Elite/Vaf/Model/MergeTests/TireTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Model_MergeTests_TireTest extends VF_TestCase
+class Elite_Vaf_Model_MergeTests_TireTest extends Elite_TestCase
 {
     function doSetUp()
     {

--- a/app/code/local/Elite/Vaf/Model/MergeTests/WheelsTest.php
+++ b/app/code/local/Elite/Vaf/Model/MergeTests/WheelsTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Model_MergeTests_WheelsTest extends VF_TestCase
+class Elite_Vaf_Model_MergeTests_WheelsTest extends Elite_TestCase
 {
     function doSetUp()
     {

--- a/app/code/local/Elite/Vaf/Model/Observer.php
+++ b/app/code/local/Elite/Vaf/Model/Observer.php
@@ -36,8 +36,8 @@ class Elite_Vaf_Model_Observer extends Mage_Core_Model_Abstract
         );
         $resource = Mage::getSingleton('core/resource');
         $read = $resource->getConnection('core_read');
-        VF_Singleton::getInstance()->setReadAdapter($read);
-        VF_Singleton::getInstance()->setProcessURL('/vaf/ajax/process?');
+        Elite_Vaf_Singleton::getInstance()->setReadAdapter($read);
+        Elite_Vaf_Singleton::getInstance()->setProcessURL('/vaf/ajax/process?');
     }
 
     function catalogProductEditAction($event)
@@ -150,7 +150,7 @@ class Elite_Vaf_Model_Observer extends Mage_Core_Model_Abstract
     /** array('order'=>$order, 'quote'=>$this->getQuote()) */
     function checkoutSaveOrder($event)
     {
-        $fit_id = VF_Singleton::getInstance()->getFitId();
+        $fit_id = Elite_Vaf_Singleton::getInstance()->getFitId();
         if ($fit_id) {
             $event->order->setEliteFit($fit_id);
         }
@@ -173,6 +173,6 @@ class Elite_Vaf_Model_Observer extends Mage_Core_Model_Abstract
     /** @return Zend_Db_Adapter_Abstract */
     protected function getReadAdapter()
     {
-        return VF_Singleton::getInstance()->getReadAdapter();
+        return Elite_Vaf_Singleton::getInstance()->getReadAdapter();
     }
 }

--- a/app/code/local/Elite/Vaf/Model/ObserverTests/ObserverDeleteMappingTest.php
+++ b/app/code/local/Elite/Vaf/Model/ObserverTests/ObserverDeleteMappingTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Model_ObserverDeleteMappingTest extends VF_TestCase
+class Elite_Vaf_Model_ObserverDeleteMappingTest extends Elite_TestCase
 {
     const PRODUCT_ID = 1;
 
@@ -50,7 +50,7 @@ class Elite_Vaf_Model_ObserverDeleteMappingTest extends VF_TestCase
             'model' => $vehicle->getLevel('model')->getId(),
             'year' => $vehicle->getLevel('year')->getId()
         ));
-        $helper = new VF_Singleton;
+        $helper = new Elite_Vaf_Singleton;
         $helper->setRequest( $request );
         $this->assertEquals( array(0), $helper->getProductIds(), 'deleting fitments should result in there being no fitments' );
     }

--- a/app/code/local/Elite/Vaf/Model/ObserverTests/TestCase.php
+++ b/app/code/local/Elite/Vaf/Model/ObserverTests/TestCase.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Model_ObserverTests_TestCase extends VF_TestCase
+class Elite_Vaf_Model_ObserverTests_TestCase extends Elite_TestCase
 {
     function observer($request)
     {

--- a/app/code/local/Elite/Vaf/Model/SearchLayer.php
+++ b/app/code/local/Elite/Vaf/Model/SearchLayer.php
@@ -41,7 +41,7 @@ class Elite_Vaf_Model_SearchLayer extends Mage_CatalogSearch_Model_Layer
             $collection->addSearchFilter(Mage::helper('catalogsearch')->getQuery()->getQueryText());
         }
         
-        $ids = VF_Singleton::getInstance()->getProductIds();
+        $ids = Elite_Vaf_Singleton::getInstance()->getProductIds();
         if($ids)
         {
             $collection->addIdFilter($ids);

--- a/app/code/local/Elite/Vaf/Model/Settings/Category.php
+++ b/app/code/local/Elite/Vaf/Model/Settings/Category.php
@@ -84,7 +84,7 @@ The splash page that is shown can be edited in vaf/splash.phtml ',
     {
         if (!$this->config instanceof Zend_Config)
         {
-            $this->config = VF_Singleton::getInstance()->getConfig();
+            $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
         }
         return $this->config;
     }

--- a/app/code/local/Elite/Vaf/Model/Settings/Categorychooser.php
+++ b/app/code/local/Elite/Vaf/Model/Settings/Categorychooser.php
@@ -76,7 +76,7 @@ Ignores any category IDs listed, they will not show up in the "category chooser"
     {
 	if (!$this->config instanceof Zend_Config)
 	{
-	    $this->config = VF_Singleton::getInstance()->getConfig();
+	    $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
 	}
 	return $this->config;
     }

--- a/app/code/local/Elite/Vaf/Model/Settings/Garage.php
+++ b/app/code/local/Elite/Vaf/Model/Settings/Garage.php
@@ -47,7 +47,7 @@ Set to true to collapse the "year/make/model" search block. If enabled, the cust
     {
 	if (!$this->config instanceof Zend_Config)
 	{
-	    $this->config = VF_Singleton::getInstance()->getConfig();
+	    $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
 	}
 	return $this->config;
     }

--- a/app/code/local/Elite/Vaf/Model/Settings/Homepagesearch.php
+++ b/app/code/local/Elite/Vaf/Model/Settings/Homepagesearch.php
@@ -51,7 +51,7 @@ Valid values are "group", "category" or "grid".
     {
 	if (!$this->config instanceof Zend_Config)
 	{
-	    $this->config = VF_Singleton::getInstance()->getConfig();
+	    $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
 	}
 	return $this->config;
     }

--- a/app/code/local/Elite/Vaf/Model/Settings/Logo.php
+++ b/app/code/local/Elite/Vaf/Model/Settings/Logo.php
@@ -50,7 +50,7 @@ class Elite_Vaf_Model_Settings_Logo extends Zend_Form
     {
 	if (!$this->config instanceof Zend_Config)
 	{
-	    $this->config = VF_Singleton::getInstance()->getConfig();
+	    $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
 	}
 	return $this->config;
     }

--- a/app/code/local/Elite/Vaf/Model/Settings/Product.php
+++ b/app/code/local/Elite/Vaf/Model/Settings/Product.php
@@ -45,7 +45,7 @@ class Elite_Vaf_Model_Settings_Product extends Zend_Form
     {
 	if (!$this->config instanceof Zend_Config)
 	{
-	    $this->config = VF_Singleton::getInstance()->getConfig();
+	    $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
 	}
 	return $this->config;
     }

--- a/app/code/local/Elite/Vaf/Model/Settings/Search.php
+++ b/app/code/local/Elite/Vaf/Model/Settings/Search.php
@@ -120,7 +120,7 @@ Before the user completely makes all selections you have several drop downs that
     {
 	if (!$this->config instanceof Zend_Config)
 	{
-	    $this->config = VF_Singleton::getInstance()->getConfig();
+	    $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
 	}
 	return $this->config;
     }

--- a/app/code/local/Elite/Vaf/Model/SplitTest.php
+++ b/app/code/local/Elite/Vaf/Model/SplitTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Model_SplitTest extends VF_TestCase
+class Elite_Vaf_Model_SplitTest extends Elite_TestCase
 {
     function doSetUp()
     {

--- a/app/code/local/Elite/Vaf/Model/SplitTests/FitmentNotesTest.php
+++ b/app/code/local/Elite/Vaf/Model/SplitTests/FitmentNotesTest.php
@@ -22,7 +22,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Elite_Vaf_Model_SplitTests_FitmentNotesTest extends VF_TestCase
+class Elite_Vaf_Model_SplitTests_FitmentNotesTest extends Elite_TestCase
 {
 
     function doSetUp()

--- a/app/code/local/Elite/Vaf/Model/SplitTests/PaintTest.php
+++ b/app/code/local/Elite/Vaf/Model/SplitTests/PaintTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Model_SplitTests_PaintTest extends VF_TestCase
+class Elite_Vaf_Model_SplitTests_PaintTest extends Elite_TestCase
 {
     const NEWLINE = "\n";
 

--- a/app/code/local/Elite/Vaf/Model/SplitTests/TireTest.php
+++ b/app/code/local/Elite/Vaf/Model/SplitTests/TireTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Model_SplitTests_TireTest extends VF_TestCase
+class Elite_Vaf_Model_SplitTests_TireTest extends Elite_TestCase
 {
     function doSetUp()
     {

--- a/app/code/local/Elite/Vaf/Model/SplitTests/WheelTest.php
+++ b/app/code/local/Elite/Vaf/Model/SplitTests/WheelTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Model_SplitTests_WheelsTest extends VF_TestCase
+class Elite_Vaf_Model_SplitTests_WheelsTest extends Elite_TestCase
 {
     function doSetUp()
     {

--- a/app/code/local/Elite/Vaf/Singleton.php
+++ b/app/code/local/Elite/Vaf/Singleton.php
@@ -1,0 +1,116 @@
+<?php
+
+
+class Elite_Vaf_Singleton extends VF_Singleton
+{
+    /** @return Elite_Vaf_Singleton */
+    static function getInstance($new = false) // test only
+    {
+        if (is_null(self::$instance) || $new) {
+            self::$instance = new Elite_Vaf_Singleton;
+        }
+        return self::$instance;
+    }
+
+    function flexibleSearch()
+    {
+        $search = parent::flexibleSearch();
+        if ($this->shouldEnableVafWheelModule()) {
+            $search = new Elite_Vafwheel_Model_FlexibleSearch($search);
+        }
+        if ($this->shouldEnableVaftireModule()) {
+            $search = new Elite_Vaftire_Model_FlexibleSearch($search);
+        }
+        if ($this->shouldEnableVafwheeladapterModule()) {
+            $search = new Elite_Vafwheeladapter_Model_FlexibleSearch($search);
+        }
+        return $search;
+    }
+
+    function ensureDefaultSectionsExist($config)
+    {
+        parent::ensureDefaultSectionsExist($config);
+        $this->ensureSectionExists($config, 'modulestatus');
+    }
+
+    function storeFitInSession()
+    {
+        $search = $this->flexibleSearch();
+        $mapping_id = $search->storeFitInSession();
+
+        if ($this->shouldEnableVaftireModule()) {
+            $tireSearch = new Elite_Vaftire_Model_FlexibleSearch($search);
+            $tireSearch->storeTireSizeInSession();
+        }
+        if ($this->shouldEnableVafWheelModule()) {
+            $wheelSearch = new Elite_Vafwheel_Model_FlexibleSearch($search);
+            $wheelSearch->storeSizeInSession();
+        }
+        if ($this->shouldEnableVafwheeladapterModule()) {
+            $wheeladapterSearch = new Elite_Vafwheeladapter_Model_FlexibleSearch($search);
+            $wheeladapterSearch->storeAdapterSizeInSession();
+        }
+        return $mapping_id;
+    }
+
+    public function shouldEnableVafWheelModule()
+    {
+        if (!$this->getConfig()->modulestatus->enableVafwheel) {
+            return false;
+        }
+        if (!file_exists(ELITE_PATH . '/Vafwheel')) {
+            throw new Exception(sprintf(
+                "You tried to enable Vafwheel however it does not exist in %s",
+                ELITE_PATH . '/Vafwheel'
+            ));
+        }
+        return true;
+    }
+
+    public function shouldEnableVaftireModule()
+    {
+        if (!$this->getConfig()->modulestatus->enableVaftire) {
+            return false;
+        }
+        if (!file_exists(ELITE_PATH . '/Vaftire')) {
+            throw new Exception(sprintf(
+                "You tried to enable Vaftire however it does not exist in %s",
+                ELITE_PATH . '/Vaftire'
+            ));
+        }
+        return true;
+    }
+
+
+    public function shouldEnableVafwheeladapterModule()
+    {
+        if (!$this->getConfig()->modulestatus->enableVafwheeladapter) {
+            return false;
+        }
+        if (!file_exists(ELITE_PATH . '/Vafwheeladapter')) {
+            throw new Exception(sprintf(
+                "You tried to enable Vafwheeladapter however it does not exist in %s",
+                ELITE_PATH . '/Vafwheeladapter'
+            ));
+        }
+        return true;
+    }
+
+    public function getRequest()
+    {
+        if (defined('ELITE_TESTING')) {
+            return parent::getRequest();
+        }
+        // get Magento request
+        if (class_exists('Mage', false)) {
+            if ($controller = Mage::app()->getFrontController()) {
+                return $controller->getRequest();
+            } else {
+                throw new Exception(Mage::helper('core')->__("Can't retrieve request object"));
+            }
+        }
+
+
+    }
+
+}

--- a/app/code/local/Elite/Vaf/SnippetTest.php
+++ b/app/code/local/Elite/Vaf/SnippetTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_SnippetTest extends VF_TestCase
+class Elite_Vaf_SnippetTest extends Elite_TestCase
 {
     const MAKE = 'Honda_Unique';
     const MODEL = 'Civic';
@@ -31,7 +31,7 @@ class Elite_Vaf_SnippetTest extends VF_TestCase
     {
         $vehicle = $this->createMMY( self::MAKE, self::MODEL, self::YEAR );
         $request = $this->getRequest( $vehicle->toValueArray() );
-        $helper = new VF_Singleton();
+        $helper = new Elite_Vaf_Singleton();
         $helper->setRequest( $request );
         $vehicle = $helper->vehicleSelection();                                                              
         $this->assertMMYTitlesEquals( self::MAKE, self::MODEL, self::YEAR, $vehicle );

--- a/app/code/local/Elite/Vaf/bootstrap-tests.php
+++ b/app/code/local/Elite/Vaf/bootstrap-tests.php
@@ -65,7 +65,7 @@ $database = new VF_TestDbAdapter(array(
     'username' => VAF_DB_USERNAME,
     'password' => VAF_DB_PASSWORD
 ));
-VF_Singleton::getInstance()->setReadAdapter($database);
+Elite_Vaf_Singleton::getInstance()->setReadAdapter($database);
 
 # used to autoload the Mage_ classes
 function my_autoload($class_name) {

--- a/app/code/local/Elite/Vaf/bootstrap.php
+++ b/app/code/local/Elite/Vaf/bootstrap.php
@@ -32,7 +32,7 @@ require_once( __DIR__.'/../vendor/autoload.php' );
 
 $resource = Mage::getSingleton('core/resource');
 $read = $resource->getConnection('core_read');
-VF_Singleton::getInstance()->setReadAdapter($read);
+Elite_Vaf_Singleton::getInstance()->setReadAdapter($read);
 
 set_include_path(
     PATH_SEPARATOR . MAGE_PATH . '/lib/'

--- a/app/code/local/Elite/Vaf/config.default.ini
+++ b/app/code/local/Elite/Vaf/config.default.ini
@@ -190,3 +190,14 @@ Y2KMode = true
 
 [tire]
 populateWhenSelectVehicle = false
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Module Status Configuration - Controls which modules get executed at runtime. Disabling what modules aren't used will save cpu cycles.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+[modulestatus]
+
+enableVafwheel = true
+
+enableVaftire = true
+
+enableVafwheeladapter = true

--- a/app/code/local/Elite/Vaf/controllers/Admin/DefinitionsTests/DefinitionsTest.php
+++ b/app/code/local/Elite/Vaf/controllers/Admin/DefinitionsTests/DefinitionsTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Adminhtml_Block_DefinitionsTests_DefinitionTest extends VF_TestCase
+class Elite_Vaf_Adminhtml_Block_DefinitionsTests_DefinitionTest extends Elite_TestCase
 {
     
     function testConstruct()

--- a/app/code/local/Elite/Vaf/controllers/Admin/DefinitionsTests/ShouldGetDefaultLevelFOOTest.php
+++ b/app/code/local/Elite/Vaf/controllers/Admin/DefinitionsTests/ShouldGetDefaultLevelFOOTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Adminhtml_Block_DefinitionsTests_ShouldGetDefaultLevelFOOTest extends VF_TestCase
+class Elite_Vaf_Adminhtml_Block_DefinitionsTests_ShouldGetDefaultLevelFOOTest extends Elite_TestCase
 {
     function doSetUp()
     {

--- a/app/code/local/Elite/Vaf/controllers/Admin/DefinitionsTests/ShouldGetDefaultLevelMMYTest.php
+++ b/app/code/local/Elite/Vaf/controllers/Admin/DefinitionsTests/ShouldGetDefaultLevelMMYTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Adminhtml_Block_DefinitionsTests_ShouldGetDefaultLevelMMYTest extends VF_TestCase
+class Elite_Vaf_Adminhtml_Block_DefinitionsTests_ShouldGetDefaultLevelMMYTest extends Elite_TestCase
 {
     function testDefaultLevel()
     {

--- a/app/code/local/Elite/Vaf/controllers/Admin/DefinitionsTests/ShouldGetEntityTest.php
+++ b/app/code/local/Elite/Vaf/controllers/Admin/DefinitionsTests/ShouldGetEntityTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Adminhtml_Block_DefinitionsTests_ShouldGetEntityTest extends VF_TestCase
+class Elite_Vaf_Adminhtml_Block_DefinitionsTests_ShouldGetEntityTest extends Elite_TestCase
 {
 
     function testGetEntityDefaultsToRootLevel()

--- a/app/code/local/Elite/Vaf/controllers/Admin/DefinitionsTests/ShouldSaveTest.php
+++ b/app/code/local/Elite/Vaf/controllers/Admin/DefinitionsTests/ShouldSaveTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaf_Adminhtml_Block_DefinitionsTests_ShouldSaveTest extends VF_TestCase
+class Elite_Vaf_Adminhtml_Block_DefinitionsTests_ShouldSaveTest extends Elite_TestCase
 {
     const TITLE = 'test title';
     const ARBITRARY_STRING = 'sdfsdf';

--- a/app/code/local/Elite/Vaf/controllers/Admin/SchemaController.php
+++ b/app/code/local/Elite/Vaf/controllers/Admin/SchemaController.php
@@ -94,6 +94,6 @@ class Elite_Vaf_Admin_SchemaController extends Mage_Adminhtml_Controller_Action
     
     function query($sql)
     {
-        return VF_Singleton::getInstance()->getReadAdapter()->query($sql);
+        return Elite_Vaf_Singleton::getInstance()->getReadAdapter()->query($sql);
     }     
 }

--- a/app/code/local/Elite/Vaf/controllers/Admin/VehicleslistController.php
+++ b/app/code/local/Elite/Vaf/controllers/Admin/VehicleslistController.php
@@ -227,7 +227,7 @@ class Elite_Vaf_Admin_VehicleslistController extends Mage_Adminhtml_Controller_A
         $this->block = $this->getLayout()->createBlock('adminhtml/vaf_definitions', 'vaf' );
         $this->block->setTemplate( 'vf/vaf/product.phtml' );
 
-        $this->block->products = VF_Singleton::getInstance()->getProductIds();
+        $this->block->products = Elite_Vaf_Singleton::getInstance()->getProductIds();
 
         $this->_addContent( $this->block );
         $this->renderLayout();
@@ -346,7 +346,7 @@ class Elite_Vaf_Admin_VehicleslistController extends Mage_Adminhtml_Controller_A
         if( !$this->config instanceof Zend_Config )
         {
 
-            $this->config = VF_Singleton::getInstance()->getConfig();
+            $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
         }
         return $this->config;
     }

--- a/app/code/local/Elite/Vaf/controllers/Admin/VfdataController.php
+++ b/app/code/local/Elite/Vaf/controllers/Admin/VfdataController.php
@@ -118,7 +118,7 @@ class Elite_Vaf_Admin_VfdataController extends Mage_Adminhtml_Controller_Action
     function getConfig()
     {
         if (!$this->config instanceof Zend_Config) {
-            $this->config = VF_Singleton::getInstance()->getConfig();
+            $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
         }
         return $this->config;
     }

--- a/app/code/local/Elite/Vaf/controllers/CartController.php
+++ b/app/code/local/Elite/Vaf/controllers/CartController.php
@@ -44,7 +44,7 @@ class Elite_Vaf_CartController extends Mage_Checkout_CartController
     {
         if( $this->customerAlreadySelectedFit() )
         {
-            $ids = VF_Singleton::getInstance()->getProductIds();
+            $ids = Elite_Vaf_Singleton::getInstance()->getProductIds();
             $product = $this->getRequest()->getParam( 'product' );
             if( in_array( $product, $ids ) )
             {
@@ -97,7 +97,7 @@ class Elite_Vaf_CartController extends Mage_Checkout_CartController
     
     protected function customerAlreadySelectedFit()
     {
-        return !VF_Singleton::getInstance()->vehicleSelection()->isEmpty();
+        return !Elite_Vaf_Singleton::getInstance()->vehicleSelection()->isEmpty();
     }
     
     protected function getProductId()
@@ -146,7 +146,7 @@ class Elite_Vaf_CartController extends Mage_Checkout_CartController
     {
         if( !$this->config instanceof Zend_Config )
         {
-            $this->config = VF_Singleton::getInstance()->getConfig();
+            $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
         }    
         return $this->config;
     }

--- a/app/code/local/Elite/Vaf/controllers/CartControllerTest.php
+++ b/app/code/local/Elite/Vaf/controllers/CartControllerTest.php
@@ -22,7 +22,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 require_once 'CartController.php';
-class Elite_Vaf_controllers_CartControllerTest extends VF_TestCase
+class Elite_Vaf_controllers_CartControllerTest extends Elite_TestCase
 {
     function testShouldGetGlobalConfig()
     {

--- a/app/code/local/Elite/Vaf/controllers/ProductController.php
+++ b/app/code/local/Elite/Vaf/controllers/ProductController.php
@@ -27,7 +27,7 @@ class Elite_Vaf_ProductController extends Mage_Catalog_ProductController
 {
     function listAction()
     { 
-        $helper = VF_Singleton::getInstance();
+        $helper = Elite_Vaf_Singleton::getInstance();
         
         $helper->setRequest( $this->getRequest() );
         $helper->storeFitInSession();
@@ -39,7 +39,7 @@ class Elite_Vaf_ProductController extends Mage_Catalog_ProductController
         
         
         $this->myLoadLayout();
-        switch( VF_Singleton::getInstance()->getConfig()->homepagesearch->mode )
+        switch( Elite_Vaf_Singleton::getInstance()->getConfig()->homepagesearch->mode )
         {
             case 'grid':
                 // set in layout.xml

--- a/app/code/local/Elite/Vaf/controllers/ProductControllerTest.php
+++ b/app/code/local/Elite/Vaf/controllers/ProductControllerTest.php
@@ -22,7 +22,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 require_once 'ProductController.php';
-class Elite_Vaf_controllers_ProductControllerTest extends VF_TestCase
+class Elite_Vaf_controllers_ProductControllerTest extends Elite_TestCase
 {
     const MAKE = 'Honda';
     const MODEL = 'Civic';

--- a/app/code/local/Elite/Vaf/etc/config.xml
+++ b/app/code/local/Elite/Vaf/etc/config.xml
@@ -3,7 +3,7 @@
 <config>
     <modules>
         <Elite_Vaf>
-            <version>v2-build44</version>
+            <version>v2.1-build1</version>
         </Elite_Vaf>
     </modules>
     

--- a/app/code/local/Elite/Vafbundle/Model/Bundle/Option.php
+++ b/app/code/local/Elite/Vafbundle/Model/Bundle/Option.php
@@ -27,7 +27,7 @@ class Elite_Vafbundle_Model_Bundle_Option extends Mage_Bundle_Model_Option
     {
 	$startTime = time();
 
-        $vehicle = VF_Singleton::getInstance()->vehicleSelection();
+        $vehicle = Elite_Vaf_Singleton::getInstance()->vehicleSelection();
         
         if( Mage::app()->getStore()->isAdmin() )
         {
@@ -47,7 +47,7 @@ class Elite_Vafbundle_Model_Bundle_Option extends Mage_Bundle_Model_Option
         
         if( $vehicle && $vehicle->getLeafValue() )
         {
-	    $productIds = VF_Singleton::getInstance()->getProductIds();
+	    $productIds = Elite_Vaf_Singleton::getInstance()->getProductIds();
 
 	    $return = array();
             foreach( $selections as $product )

--- a/app/code/local/Elite/Vafbundle/etc/config.xml
+++ b/app/code/local/Elite/Vafbundle/etc/config.xml
@@ -3,7 +3,7 @@
 <config>
     <modules>
         <Elite_Vaf>
-            <version>v2-build44</version>
+            <version>v2.1-build1</version>
         </Elite_Vaf>
     </modules>
     <global>

--- a/app/code/local/Elite/Vafdiagram/Model/Catalog/Product.php
+++ b/app/code/local/Elite/Vafdiagram/Model/Catalog/Product.php
@@ -173,7 +173,7 @@ class Elite_Vafdiagram_Model_Catalog_Product
     /** @return Zend_Db_Adapter_Abstract */
     protected function getReadAdapter()
     {
-	return VF_Singleton::getInstance()->getReadAdapter();
+	return Elite_Vaf_Singleton::getInstance()->getReadAdapter();
     }
 
 }

--- a/app/code/local/Elite/Vafdiagram/Model/CategoryFinder.php
+++ b/app/code/local/Elite/Vafdiagram/Model/CategoryFinder.php
@@ -85,6 +85,6 @@ class Elite_Vafdiagram_Model_CategoryFinder
     /** @return Zend_Db_Adapter_Abstract */
     protected function getReadAdapter()
     {
-        return VF_Singleton::getInstance()->getReadAdapter();
+        return Elite_Vaf_Singleton::getInstance()->getReadAdapter();
     }
 }

--- a/app/code/local/Elite/Vafdiagram/Model/ProductFinder.php
+++ b/app/code/local/Elite/Vafdiagram/Model/ProductFinder.php
@@ -86,7 +86,7 @@ class Elite_Vafdiagram_Model_ProductFinder
     /** @return Zend_Db_Adapter_Abstract */
     protected function getReadAdapter()
     {
-	return VF_Singleton::getInstance()->getReadAdapter();
+	return Elite_Vaf_Singleton::getInstance()->getReadAdapter();
     }
 
 }

--- a/app/code/local/Elite/Vafdiagram/Model/TestCase.php
+++ b/app/code/local/Elite/Vafdiagram/Model/TestCase.php
@@ -22,7 +22,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-abstract class Elite_Vafdiagram_Model_TestCase extends VF_TestCase
+abstract class Elite_Vafdiagram_Model_TestCase extends Elite_TestCase
 {
 
     function import($data)

--- a/app/code/local/Elite/Vafdiagram/Model/Vehicle.php
+++ b/app/code/local/Elite/Vafdiagram/Model/Vehicle.php
@@ -58,6 +58,6 @@ class Elite_Vafdiagram_Model_Vehicle
  	/** @return Zend_Db_Adapter_Abstract */
     protected function getReadAdapter()
     {
-        return VF_Singleton::getInstance()->getReadAdapter();
+        return Elite_Vaf_Singleton::getInstance()->getReadAdapter();
     }
 }

--- a/app/code/local/Elite/Vafgarage/Model/GarageTest.php
+++ b/app/code/local/Elite/Vafgarage/Model/GarageTest.php
@@ -22,7 +22,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Elite_Vafgarage_Model_GarageTest extends VF_TestCase {
+class Elite_Vafgarage_Model_GarageTest extends Elite_TestCase {
 
     function testAddVehicle() {
         $garage = new Elite_Vafgarage_Model_Garage;

--- a/app/code/local/Elite/Vafgarage/etc/config.xml
+++ b/app/code/local/Elite/Vafgarage/etc/config.xml
@@ -3,7 +3,7 @@
 <config>
     <modules>
         <Elite_Vafgarage>
-            <version>v2-build44</version>
+            <version>v2.1-build1</version>
         </Elite_Vafgarage>
     </modules>
     

--- a/app/code/local/Elite/Vafimporter/controllers/Admin/VafdefinitionsimporterController.php
+++ b/app/code/local/Elite/Vafimporter/controllers/Admin/VafdefinitionsimporterController.php
@@ -114,7 +114,7 @@ class Elite_Vafimporter_Admin_VafdefinitionsimporterController extends Mage_Admi
     {
         // profiling
         $profiler = new My_Zend_Db_Profiler;
-        VF_Singleton::getInstance()->getReadAdapter()->setProfiler($profiler);
+        Elite_Vaf_Singleton::getInstance()->getReadAdapter()->setProfiler($profiler);
         $profiler->setEnabled(true);
         
         try
@@ -196,7 +196,7 @@ class Elite_Vafimporter_Admin_VafdefinitionsimporterController extends Mage_Admi
     /** @return Zend_Db_Adapter_Abstract */
     protected function getReadAdapter()
     {
-        return VF_Singleton::getInstance()->getReadAdapter();
+        return Elite_Vaf_Singleton::getInstance()->getReadAdapter();
     }
 
     protected function checkVersion()

--- a/app/code/local/Elite/Vafimporter/etc/config.xml
+++ b/app/code/local/Elite/Vafimporter/etc/config.xml
@@ -3,7 +3,7 @@
 <config>
     <modules>
         <Elite_Vaf>
-            <version>v2-build44</version>
+            <version>v2.1-build1</version>
         </Elite_Vaf>
     </modules>
     <global>

--- a/app/code/local/Elite/Vafinstall/DatabaseVersion.php
+++ b/app/code/local/Elite/Vafinstall/DatabaseVersion.php
@@ -31,6 +31,6 @@ class Elite_Vafinstall_DatabaseVersion
     
     function db()
     {
-        return VF_Singleton::getInstance()->getReadAdapter();
+        return Elite_Vaf_Singleton::getInstance()->getReadAdapter();
     }
 }

--- a/app/code/local/Elite/Vafinstall/MigrateBase.php
+++ b/app/code/local/Elite/Vafinstall/MigrateBase.php
@@ -159,6 +159,6 @@ abstract class Elite_Vafinstall_MigrateBase
     
     function db()
     {
-		return VF_Singleton::getInstance()->getReadAdapter();
+		return Elite_Vaf_Singleton::getInstance()->getReadAdapter();
     }
 }

--- a/app/code/local/Elite/Vaflinks/Block/CMSListTests/MMYTest.php
+++ b/app/code/local/Elite/Vaflinks/Block/CMSListTests/MMYTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaflinks_Block_CMSListTest extends VF_TestCase {
+class Elite_Vaflinks_Block_CMSListTest extends Elite_TestCase {
 
     function testShouldDisableOutput()
     {

--- a/app/code/local/Elite/Vaflinks/Block/CMSListTests/YMMTest.php
+++ b/app/code/local/Elite/Vaflinks/Block/CMSListTests/YMMTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaflinks_Block_CMSListYMMTest extends VF_TestCase {
+class Elite_Vaflinks_Block_CMSListYMMTest extends Elite_TestCase {
 
     function doSetUp()
     {

--- a/app/code/local/Elite/Vaflinks/Block/CMSTest.php
+++ b/app/code/local/Elite/Vaflinks/Block/CMSTest.php
@@ -22,7 +22,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Elite_Vaflinks_Block_CMSTest extends VF_TestCase
+class Elite_Vaflinks_Block_CMSTest extends Elite_TestCase
 {
 
     function testShouldDisableOutput()

--- a/app/code/local/Elite/Vaflinks/Block/List.php
+++ b/app/code/local/Elite/Vaflinks/Block/List.php
@@ -30,7 +30,7 @@ class Elite_Vaflinks_Block_List extends Elite_Vaf_Block_Search {
     }
 
     function getDefinitions() {
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
 
         if ($this->lastLevelAlreadySelected()) {
             return array();
@@ -97,7 +97,7 @@ class Elite_Vaflinks_Block_List extends Elite_Vaf_Block_Search {
     }
     
     function isEnabled() {
-        return (bool)VF_Singleton::getInstance()->enableDirectory();
+        return (bool)Elite_Vaf_Singleton::getInstance()->enableDirectory();
     }
 
 }

--- a/app/code/local/Elite/Vaflinks/Block/ListTest.php
+++ b/app/code/local/Elite/Vaflinks/Block/ListTest.php
@@ -22,7 +22,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Elite_Vaflinks_Block_ListTest extends VF_TestCase {
+class Elite_Vaflinks_Block_ListTest extends Elite_TestCase {
 
     function testShouldListMakes() {
         $vehicle = $this->createMMY('Honda', 'Civic', '2000');
@@ -95,7 +95,7 @@ class Elite_Vaflinks_Block_ListTest extends VF_TestCase {
         $block->setRequest($request);
         $html = $block->toHtml();
 
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
 
         // list years
         $block = new Elite_Vaflinks_Block_ListTestSub;
@@ -119,7 +119,7 @@ class Elite_Vaflinks_Block_ListTest extends VF_TestCase {
         $block->setRequest($request);
         $html = $block->toHtml();
 
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
 
         // list years
         $block = new Elite_Vaflinks_Block_ListTestSub;

--- a/app/code/local/Elite/Vaflinks/etc/config.xml
+++ b/app/code/local/Elite/Vaflinks/etc/config.xml
@@ -3,7 +3,7 @@
 <config>
     <modules>
         <Elite_Vaflinks>
-            <version>v2-build44</version>
+            <version>v2.1-build1</version>
         </Elite_Vaflinks>
     </modules>
     <global>

--- a/app/code/local/Elite/Vaflogo/Block/ListTest.php
+++ b/app/code/local/Elite/Vaflogo/Block/ListTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaflogo_Block_ListMMYTest extends VF_TestCase
+class Elite_Vaflogo_Block_ListMMYTest extends Elite_TestCase
 {
 
     function doSetUp()

--- a/app/code/local/Elite/Vaflogo/Block/ListYMMTest.php
+++ b/app/code/local/Elite/Vaflogo/Block/ListYMMTest.php
@@ -20,7 +20,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaflogo_Block_ListYMMTest extends VF_TestCase
+class Elite_Vaflogo_Block_ListYMMTest extends Elite_TestCase
 {
 
     function doSetUp()

--- a/app/code/local/Elite/Vaflogo/Block/Logo.php
+++ b/app/code/local/Elite/Vaflogo/Block/Logo.php
@@ -32,7 +32,7 @@ class Elite_Vaflogo_Block_Logo extends Mage_Core_Block_Abstract
     {
         if( !$this->config instanceof Zend_Config )
         {
-            $this->config = VF_Singleton::getInstance()->getConfig();
+            $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
         }
         return $this->config;
     }
@@ -44,7 +44,7 @@ class Elite_Vaflogo_Block_Logo extends Mage_Core_Block_Abstract
 
     function _toHtml()
     {
-	if (VF_Singleton::getInstance()->getConfig()->logo->disable)
+	if (Elite_Vaf_Singleton::getInstance()->getConfig()->logo->disable)
 	{
 	    return;
 	}
@@ -67,7 +67,7 @@ class Elite_Vaflogo_Block_Logo extends Mage_Core_Block_Abstract
 
     function selectionPart()
     {
-	$vehicleSelection = VF_Singleton::getInstance()->vehicleSelection();
+	$vehicleSelection = Elite_Vaf_Singleton::getInstance()->vehicleSelection();
 	if ($vehicleSelection->isEmpty())
 	{
 	    return false;

--- a/app/code/local/Elite/Vaflogo/Block/LogoTests/MMYTest.php
+++ b/app/code/local/Elite/Vaflogo/Block/LogoTests/MMYTest.php
@@ -22,7 +22,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Elite_Vaflogo_Block_LogoTests_MMYTest extends VF_TestCase
+class Elite_Vaflogo_Block_LogoTests_MMYTest extends Elite_TestCase
 {
 
     function doSetUp()

--- a/app/code/local/Elite/Vaflogo/Block/LogoTests/MYTest.php
+++ b/app/code/local/Elite/Vaflogo/Block/LogoTests/MYTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaflogo_Block_LogoTests_MYTest extends VF_TestCase
+class Elite_Vaflogo_Block_LogoTests_MYTest extends Elite_TestCase
 {
 
     function doSetUp()

--- a/app/code/local/Elite/Vaflogo/Block/LogoTests/YMMTest.php
+++ b/app/code/local/Elite/Vaflogo/Block/LogoTests/YMMTest.php
@@ -22,7 +22,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Elite_Vaflogo_Block_LogoTests_YMMTest extends VF_TestCase
+class Elite_Vaflogo_Block_LogoTests_YMMTest extends Elite_TestCase
 {
 
     function doSetUp()

--- a/app/code/local/Elite/Vaflogo/etc/config.xml
+++ b/app/code/local/Elite/Vaflogo/etc/config.xml
@@ -3,7 +3,7 @@
 <config>
     <modules>
         <Elite_Vaflogo>
-            <version>v2-build44</version>
+            <version>v2.1-build1</version>
         </Elite_Vaflogo>
     </modules>
     <global>

--- a/app/code/local/Elite/Vafnote/SnippetTest.php
+++ b/app/code/local/Elite/Vafnote/SnippetTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafnote_SnippetTest extends VF_TestCase
+class Elite_Vafnote_SnippetTest extends Elite_TestCase
 {
     const PRODUCT_ID = 1;
     const NOTE_CODE = 1;
@@ -108,7 +108,7 @@ class Elite_Vafnote_SnippetTest extends VF_TestCase
         // begin fitment fitment notes
         
         $noteFinder = new VF_Note_Finder();
-        $vehicle = VF_Singleton::getInstance()->vehicleSelection()->getFirstVehicle();
+        $vehicle = Elite_Vaf_Singleton::getInstance()->vehicleSelection()->getFirstVehicle();
         
         $product = new Elite_Vaf_Model_Catalog_Product();
         $product->setId( $product_id );

--- a/app/code/local/Elite/Vafnote/etc/config.xml
+++ b/app/code/local/Elite/Vafnote/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Elite_Vafnote>
-            <version>v2-build44</version>
+            <version>v2.1-build1</version>
         </Elite_Vafnote>
     </modules>
     

--- a/app/code/local/Elite/Vafnote/migrations/12_fix_notes.php
+++ b/app/code/local/Elite/Vafnote/migrations/12_fix_notes.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-$db = VF_Singleton::getInstance()->getReadAdapter();
+$db = Elite_Vaf_Singleton::getInstance()->getReadAdapter();
 $db->query("ALTER TABLE `elite_note` CHANGE `id` `code` VARCHAR( 50 ) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL ");
 $db->query("ALTER TABLE elite_note DROP PRIMARY KEY ");
 $db->query("ALTER TABLE `elite_note` ADD UNIQUE (`code`)");

--- a/app/code/local/Elite/Vafpaint/Model/Importer/Definitions/PaintMMYTest.php
+++ b/app/code/local/Elite/Vafpaint/Model/Importer/Definitions/PaintMMYTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafpaint_Model_Importer_Definitions_PaintMMYTest extends VF_TestCase
+class Elite_Vafpaint_Model_Importer_Definitions_PaintMMYTest extends Elite_TestCase
 {
     protected $csvData;
     protected $csvFile;

--- a/app/code/local/Elite/Vafpaint/Model/Importer/Definitions/PaintYMMTest.php
+++ b/app/code/local/Elite/Vafpaint/Model/Importer/Definitions/PaintYMMTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafpaint_Model_Importer_Definitions_PaintYMMTest extends VF_TestCase
+class Elite_Vafpaint_Model_Importer_Definitions_PaintYMMTest extends Elite_TestCase
 {
     protected $csvData;
     protected $csvFile;

--- a/app/code/local/Elite/Vafpaint/Model/Paint/Mapper.php
+++ b/app/code/local/Elite/Vafpaint/Model/Paint/Mapper.php
@@ -69,7 +69,7 @@ class Elite_Vafpaint_Model_Paint_Mapper
     /** @return Zend_Db_Adapter_Abstract */
     protected function getReadAdapter()
     {
-        return VF_Singleton::getInstance()->getReadAdapter();
+        return Elite_Vaf_Singleton::getInstance()->getReadAdapter();
     }
 
 }

--- a/app/code/local/Elite/Vafpaint/Model/Paint/MapperTest.php
+++ b/app/code/local/Elite/Vafpaint/Model/Paint/MapperTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafpaint_Model_Paint_MapperTest extends VF_TestCase
+class Elite_Vafpaint_Model_Paint_MapperTest extends Elite_TestCase
 {
 	const CODE = 'code';
 	const NAME = 'name';

--- a/app/code/local/Elite/Vafpaint/Model/PaintTest.php
+++ b/app/code/local/Elite/Vafpaint/Model/PaintTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafpaint_Model_PaintTest extends VF_TestCase
+class Elite_Vafpaint_Model_PaintTest extends Elite_TestCase
 {
     const CODE = 'B-27MZ';
     const COLOR = '#9CBBCC';

--- a/app/code/local/Elite/Vafpaint/etc/config.xml
+++ b/app/code/local/Elite/Vafpaint/etc/config.xml
@@ -4,7 +4,7 @@
 
     <modules>
         <Elite_Vafpaint>
-            <version>v2-build44</version>
+            <version>v2.1-build1</version>
         </Elite_Vafpaint>
     </modules>
 

--- a/app/code/local/Elite/Vafpaint/install-paint.php
+++ b/app/code/local/Elite/Vafpaint/install-paint.php
@@ -24,7 +24,7 @@
 require_once( 'app/Mage.php' );
 require_once( 'app/code/local/Elite/Vaf/Model/Schema/Generator.php' );
 Mage::app();
-$helper = VF_Singleton::getInstance();
+$helper = Elite_Vaf_Singleton::getInstance();
 $generator = new Elite_Vafpaint_Model_Schema_Generator;
 
 $sql = $generator->install();

--- a/app/code/local/Elite/Vafrelated/Model/Catalog/Product.php
+++ b/app/code/local/Elite/Vafrelated/Model/Catalog/Product.php
@@ -103,6 +103,6 @@ class Elite_Vafrelated_Model_Catalog_Product
     /** @return Zend_Db_Adapter_Abstract */
     protected function getReadAdapter()
     {
-        return VF_Singleton::getInstance()->getReadAdapter();
+        return Elite_Vaf_Singleton::getInstance()->getReadAdapter();
     }
 }

--- a/app/code/local/Elite/Vafrelated/Model/Catalog/ProductTest.php
+++ b/app/code/local/Elite/Vafrelated/Model/Catalog/ProductTest.php
@@ -20,7 +20,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafrelated_Model_Catalog_ProductTest extends VF_TestCase
+class Elite_Vafrelated_Model_Catalog_ProductTest extends Elite_TestCase
 {
     function testCreateNewProduct()
     {

--- a/app/code/local/Elite/Vafsitemap/Block/Product.php
+++ b/app/code/local/Elite/Vafsitemap/Block/Product.php
@@ -43,7 +43,7 @@ class Elite_Vafsitemap_Block_Product extends Mage_Catalog_Block_Seo_Sitemap_Prod
     
     function sitemap()
     {
-        return new Elite_Vafsitemap_Model_Sitemap_Product_Html(VF_Singleton::getInstance()->getConfig());
+        return new Elite_Vafsitemap_Model_Sitemap_Product_Html(Elite_Vaf_Singleton::getInstance()->getConfig());
     }
     
 }

--- a/app/code/local/Elite/Vafsitemap/Block/Vehicles.php
+++ b/app/code/local/Elite/Vafsitemap/Block/Vehicles.php
@@ -39,7 +39,7 @@ class Elite_Vafsitemap_Block_Vehicles extends Mage_Core_Block_Template implement
     {
 	if (!$this->config instanceof Zend_Config)
 	{
-	    $this->config = VF_Singleton::getInstance()->getConfig();
+	    $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
 	}
 	return $this->config;
     }
@@ -122,7 +122,7 @@ class Elite_Vafsitemap_Block_Vehicles extends Mage_Core_Block_Template implement
     /** @return Zend_Db_Adapter_Abstract */
     protected function getReadAdapter()
     {
-	return VF_Singleton::getInstance()->getReadAdapter();
+	return Elite_Vaf_Singleton::getInstance()->getReadAdapter();
     }
 
 }

--- a/app/code/local/Elite/Vafsitemap/Helper/SeoName.php
+++ b/app/code/local/Elite/Vafsitemap/Helper/SeoName.php
@@ -46,16 +46,16 @@ class Elite_Vafsitemap_Helper_SeoName
     
     protected function rewritesOn()
     {
-        return VF_Singleton::getInstance()->getConfig()->seo->rewriteProductName;
+        return Elite_Vaf_Singleton::getInstance()->getConfig()->seo->rewriteProductName;
     }
     
     protected function getFit()
     {
-        return VF_Singleton::getInstance()->vehicleSelection();
+        return Elite_Vaf_Singleton::getInstance()->vehicleSelection();
     }
     
     protected function getFitId()
     {
-        return VF_Singleton::getInstance()->getFitId();
+        return Elite_Vaf_Singleton::getInstance()->getFitId();
     }
 }

--- a/app/code/local/Elite/Vafsitemap/Helper/SeoNameTest.php
+++ b/app/code/local/Elite/Vafsitemap/Helper/SeoNameTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafsitemap_Helper_SeoNameTest extends VF_TestCase
+class Elite_Vafsitemap_Helper_SeoNameTest extends Elite_TestCase
 {
     function test1()
     {

--- a/app/code/local/Elite/Vafsitemap/Model/Sitemap/Product/GoogleBase.php
+++ b/app/code/local/Elite/Vafsitemap/Model/Sitemap/Product/GoogleBase.php
@@ -33,7 +33,7 @@ class Elite_Vafsitemap_Model_Sitemap_Product_GoogleBase extends Elite_Vafsitemap
 
 	fwrite($stream, $this->fieldNames());
 
-	$query = VF_Singleton::getInstance()->getReadAdapter()->select()
+	$query = Elite_Vaf_Singleton::getInstance()->getReadAdapter()->select()
 		->from($this->getProductTable(), array('entity_id'));
 	$rs = $query->query();
 	while($productRow = $rs->fetch())
@@ -52,7 +52,7 @@ class Elite_Vafsitemap_Model_Sitemap_Product_GoogleBase extends Elite_Vafsitemap
 
     function doProduct($product)
     {
-	$sitemap = new Elite_Vafsitemap_Model_Sitemap_Vehicle(VF_Singleton::getInstance()->getConfig());
+	$sitemap = new Elite_Vafsitemap_Model_Sitemap_Vehicle(Elite_Vaf_Singleton::getInstance()->getConfig());
 	$vehicles = $sitemap->getDefinitions(null,null,$product->getId());
 	foreach ($vehicles as $vehicle)
 	{

--- a/app/code/local/Elite/Vafsitemap/Model/Sitemap/Product/GoogleBaseTest.php
+++ b/app/code/local/Elite/Vafsitemap/Model/Sitemap/Product/GoogleBaseTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafsitemap_Model_Sitemap_Product_GoogleBaseTest extends VF_TestCase
+class Elite_Vafsitemap_Model_Sitemap_Product_GoogleBaseTest extends Elite_TestCase
 {
 	protected $make, $model, $year;
     

--- a/app/code/local/Elite/Vafsitemap/Model/Sitemap/Product/Html.php
+++ b/app/code/local/Elite/Vafsitemap/Model/Sitemap/Product/Html.php
@@ -29,7 +29,7 @@ class Elite_Vafsitemap_Model_Sitemap_Product_Html extends Elite_Vafsitemap_Model
     /** @return VF_Vehicle */
     function getSelectedDefinition()
     {
-        return VF_Singleton::getInstance()->vehicleSelection();
+        return Elite_Vaf_Singleton::getInstance()->vehicleSelection();
     }
     
     function getCollection()
@@ -52,7 +52,7 @@ class Elite_Vafsitemap_Model_Sitemap_Product_Html extends Elite_Vafsitemap_Model
     
     function filterCollectionByVehicle($collection)
     {
-		$ids = VF_Singleton::getInstance()->getProductIds();
+		$ids = Elite_Vaf_Singleton::getInstance()->getProductIds();
         $collection->addIdFilter( $ids );
         $this->filtered = true;
     }

--- a/app/code/local/Elite/Vafsitemap/Model/Sitemap/Product/HtmlTest.php
+++ b/app/code/local/Elite/Vafsitemap/Model/Sitemap/Product/HtmlTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafsitemap_Model_Sitemap_Product_HtmlTest extends VF_TestCase
+class Elite_Vafsitemap_Model_Sitemap_Product_HtmlTest extends Elite_TestCase
 {
     protected $expectedDefinition;
     protected $sitemap;
@@ -31,7 +31,7 @@ class Elite_Vafsitemap_Model_Sitemap_Product_HtmlTest extends VF_TestCase
 		$this->switchSchema('make,model,year');
 		$this->expectedDefinition = $this->createMMY();
         $this->setRequestParams( $this->expectedDefinition->toValueArray() );
-        $this->sitemap = new Elite_Vafsitemap_Model_Sitemap_Product_Sub( VF_Singleton::getInstance()->getConfig() );
+        $this->sitemap = new Elite_Vafsitemap_Model_Sitemap_Product_Sub( Elite_Vaf_Singleton::getInstance()->getConfig() );
     }
     
     function testSelectedVehicle()

--- a/app/code/local/Elite/Vafsitemap/Model/Sitemap/Product/XML.php
+++ b/app/code/local/Elite/Vafsitemap/Model/Sitemap/Product/XML.php
@@ -32,7 +32,7 @@ class Elite_Vafsitemap_Model_Sitemap_Product_XML extends Elite_Vafsitemap_Model_
         
         $record = $startRecord;
         
-        $query = VF_Singleton::getInstance()->getReadAdapter()->select()
+        $query = Elite_Vaf_Singleton::getInstance()->getReadAdapter()->select()
 		->from($this->getProductTable(), array('entity_id'));
 	$rs = $query->query();
 	while($productRow = $rs->fetch())
@@ -62,7 +62,7 @@ class Elite_Vafsitemap_Model_Sitemap_Product_XML extends Elite_Vafsitemap_Model_
 
     function fitmentCount($storeId)
     {
-        $query = VF_Singleton::getInstance()->getReadAdapter()->select()
+        $query = Elite_Vaf_Singleton::getInstance()->getReadAdapter()->select()
 		->from($this->getProductTable(), array('entity_id'));
 	$rs = $query->query();
 	while($productRow = $rs->fetch())
@@ -82,7 +82,7 @@ class Elite_Vafsitemap_Model_Sitemap_Product_XML extends Elite_Vafsitemap_Model_
     function productCount()
     {
 	$count = 0;
-	$query = VF_Singleton::getInstance()->getReadAdapter()->select()
+	$query = Elite_Vaf_Singleton::getInstance()->getReadAdapter()->select()
 		->from($this->getProductTable(), array('entity_id'));
 	$rs = $query->query();
 	while($productRow = $rs->fetch())

--- a/app/code/local/Elite/Vafsitemap/Model/Sitemap/Product/XMLTest.php
+++ b/app/code/local/Elite/Vafsitemap/Model/Sitemap/Product/XMLTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafsitemap_Model_Sitemap_Product_XMLTest extends VF_TestCase
+class Elite_Vafsitemap_Model_Sitemap_Product_XMLTest extends Elite_TestCase
 {
     function testExport()
     {

--- a/app/code/local/Elite/Vafsitemap/Model/Sitemap/VehicleTests/CountMMTCTest.php
+++ b/app/code/local/Elite/Vafsitemap/Model/Sitemap/VehicleTests/CountMMTCTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafsitemap_Model_Sitemap_VehicleTests_CountMMTCTest extends VF_TestCase
+class Elite_Vafsitemap_Model_Sitemap_VehicleTests_CountMMTCTest extends Elite_TestCase
 {
     protected $make, $model, $trim, $chassis;
     
@@ -32,13 +32,13 @@ class Elite_Vafsitemap_Model_Sitemap_VehicleTests_CountMMTCTest extends VF_TestC
     
     function testCount0()
     {
-        $sitemap = new Elite_Vafsitemap_Model_Sitemap_Vehicle(VF_Singleton::getInstance()->getConfig());
+        $sitemap = new Elite_Vafsitemap_Model_Sitemap_Vehicle(Elite_Vaf_Singleton::getInstance()->getConfig());
         $this->assertEquals( 0, $sitemap->vehicleCount() );
     }
 
     function testCount1()
     {
-        $sitemap = new Elite_Vafsitemap_Model_Sitemap_Vehicle(VF_Singleton::getInstance()->getConfig());
+        $sitemap = new Elite_Vafsitemap_Model_Sitemap_Vehicle(Elite_Vaf_Singleton::getInstance()->getConfig());
         $vehicle = $this->createMMTC();
         $this->insertMappingMMTC( $vehicle );
         $this->assertEquals( 1, $sitemap->vehicleCount() );

--- a/app/code/local/Elite/Vafsitemap/Model/Sitemap/VehicleTests/CountMMYTest.php
+++ b/app/code/local/Elite/Vafsitemap/Model/Sitemap/VehicleTests/CountMMYTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafsitemap_Model_Sitemap_VehicleTests_CountTest extends VF_TestCase
+class Elite_Vafsitemap_Model_Sitemap_VehicleTests_CountTest extends Elite_TestCase
 {
     protected $make, $model, $year;
     
@@ -33,14 +33,14 @@ class Elite_Vafsitemap_Model_Sitemap_VehicleTests_CountTest extends VF_TestCase
 
     function testWhenThereIsAMappingShouldCountTheDefinition()
     {
-        $sitemap = new Elite_Vafsitemap_Model_Sitemap_Vehicle(VF_Singleton::getInstance()->getConfig());
+        $sitemap = new Elite_Vafsitemap_Model_Sitemap_Vehicle(Elite_Vaf_Singleton::getInstance()->getConfig());
         $this->insertMappingMMY( $this->definition );
         $this->assertEquals( 1, $sitemap->vehicleCount(), 'when there is a mapping should count the definition' );
     }
 
     function testWhenThereIsNotAMappingShouldNotCountTheDefinition()
     {
-        $sitemap = new Elite_Vafsitemap_Model_Sitemap_Vehicle(VF_Singleton::getInstance()->getConfig());
+        $sitemap = new Elite_Vafsitemap_Model_Sitemap_Vehicle(Elite_Vaf_Singleton::getInstance()->getConfig());
         $this->assertEquals( 0, $sitemap->vehicleCount(), 'when there is not a mapping should not count the definition' );
     }
 

--- a/app/code/local/Elite/Vafsitemap/Model/Sitemap/VehicleTests/DefinitionMMTCTest.php
+++ b/app/code/local/Elite/Vafsitemap/Model/Sitemap/VehicleTests/DefinitionMMTCTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafsitemap_Model_Sitemap_VehicleTests_DefinitionMMTCTest extends VF_TestCase
+class Elite_Vafsitemap_Model_Sitemap_VehicleTests_DefinitionMMTCTest extends Elite_TestCase
 {
     protected $make, $model, $trim, $chassis;
     
@@ -32,7 +32,7 @@ class Elite_Vafsitemap_Model_Sitemap_VehicleTests_DefinitionMMTCTest extends VF_
 
     function testDefinitions()
     {
-        $sitemap = new Elite_Vafsitemap_Model_Sitemap_Vehicle(VF_Singleton::getInstance()->getConfig());
+        $sitemap = new Elite_Vafsitemap_Model_Sitemap_Vehicle(Elite_Vaf_Singleton::getInstance()->getConfig());
         $vehicle = $this->createMMTC();
         $this->insertMappingMMTC( $vehicle );
 

--- a/app/code/local/Elite/Vafsitemap/Model/Sitemap/VehicleTests/DefinitionMMYTest.php
+++ b/app/code/local/Elite/Vafsitemap/Model/Sitemap/VehicleTests/DefinitionMMYTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafsitemap_Model_Sitemap_VehicleTests_DefinitionMMYTest extends VF_TestCase
+class Elite_Vafsitemap_Model_Sitemap_VehicleTests_DefinitionMMYTest extends Elite_TestCase
 {
     protected $make, $model, $year;
     
@@ -34,7 +34,7 @@ class Elite_Vafsitemap_Model_Sitemap_VehicleTests_DefinitionMMYTest extends VF_T
     
     function testDefinitionsMMY()
     {
-        $sitemap = new Elite_Vafsitemap_Model_Sitemap_Vehicle(VF_Singleton::getInstance()->getConfig());
+        $sitemap = new Elite_Vafsitemap_Model_Sitemap_Vehicle(Elite_Vaf_Singleton::getInstance()->getConfig());
         $vehicles = $sitemap->getDefinitions(10);
         $this->assertTrue( $vehicles[0] instanceof VF_Vehicle );
         $this->assertNotEquals( 0, (int)$vehicles[0]->getLevel('year')->getId() );

--- a/app/code/local/Elite/Vafsitemap/Model/Url/Rewrite.php
+++ b/app/code/local/Elite/Vafsitemap/Model/Url/Rewrite.php
@@ -114,7 +114,7 @@ class Elite_Vafsitemap_Model_Url_Rewrite extends Mage_Core_Model_Url_Rewrite
 
     function getRequestPathRewritten()
     {
-        $vehicle = VF_Singleton::getInstance()->vehicleSelection();
+        $vehicle = Elite_Vaf_Singleton::getInstance()->vehicleSelection();
         return $this->getRequestPathForDefinition($vehicle);
     }
 
@@ -155,7 +155,7 @@ class Elite_Vafsitemap_Model_Url_Rewrite extends Mage_Core_Model_Url_Rewrite
     function getConfig()
     {
         if (!$this->config instanceof Zend_Config) {
-            $this->config = VF_Singleton::getInstance()->getConfig();
+            $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
         }
         return $this->config;
     }

--- a/app/code/local/Elite/Vafsitemap/Model/Url/Rewrite/SlugTest.php
+++ b/app/code/local/Elite/Vafsitemap/Model/Url/Rewrite/SlugTest.php
@@ -22,7 +22,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Vafsitemap_Model_Url_Rewrite_SlugTest extends VF_TestCase
+class Vafsitemap_Model_Url_Rewrite_SlugTest extends Elite_TestCase
 {
 
     function testSlugToVehicle()

--- a/app/code/local/Elite/Vafsitemap/Model/Url/RewriteTests/ProductListTests/RewriteURLS/MMYTest.php
+++ b/app/code/local/Elite/Vafsitemap/Model/Url/RewriteTests/ProductListTests/RewriteURLS/MMYTest.php
@@ -76,7 +76,7 @@ class Elite_Vafsitemap_Model_Url_RewriteTests_ProductListTests_RewriteURLS_MMYTe
 	$this->rewrite($request);
 	$this->setRequest($request);
 
-	VF_Singleton::getInstance()->getProductIds();
+	Elite_Vaf_Singleton::getInstance()->getProductIds();
 	$this->assertEquals($this->definition->getLevel('make')->getId(), $_SESSION['make'], 'should look up the right ID#s from the vehicle string, and store in session');
 	$this->assertEquals($this->definition->getLevel('model')->getId(), $_SESSION['model'], 'should look up the right ID#s from the vehicle string, and store in session');
 	$this->assertEquals($this->definition->getLevel('year')->getId(), $_SESSION['year'], 'should look up the right ID#s from the vehicle string, and store in session');

--- a/app/code/local/Elite/Vafsitemap/Model/Url/RewriteTests/ProductListTests/RewriteURLS/URLTemplateTest.php
+++ b/app/code/local/Elite/Vafsitemap/Model/Url/RewriteTests/ProductListTests/RewriteURLS/URLTemplateTest.php
@@ -56,7 +56,7 @@ class Elite_Vafsitemap_Model_Url_RewriteTests_ProductListTests_RewriteURLS_URLTe
         $this->rewrite($request, $config);
         $this->setRequest($request);
 
-        VF_Singleton::getInstance()->getProductIds();
+        Elite_Vaf_Singleton::getInstance()->getProductIds();
         $this->assertEquals($this->definition->getLevel('make')->getId(), $_SESSION['make'], 'should look up the right ID#s from the vehicle string, and store in session');
         $this->assertEquals($this->definition->getLevel('model')->getId(), $_SESSION['model'], 'should look up the right ID#s from the vehicle string, and store in session');
         $this->assertEquals($this->definition->getLevel('year')->getId(), $_SESSION['year'], 'should look up the right ID#s from the vehicle string, and store in session');

--- a/app/code/local/Elite/Vafsitemap/Model/Url/RewriteTests/TestCase.php
+++ b/app/code/local/Elite/Vafsitemap/Model/Url/RewriteTests/TestCase.php
@@ -22,7 +22,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-abstract class Elite_Vafsitemap_Model_Url_RewriteTests_TestCase extends VF_TestCase
+abstract class Elite_Vafsitemap_Model_Url_RewriteTests_TestCase extends Elite_TestCase
 {
 
     function getSEORequest($uri)

--- a/app/code/local/Elite/Vafsitemap/Model/Url/RewriteTests/VehicleListTests/GeneratesURLS/MMYTest.php
+++ b/app/code/local/Elite/Vafsitemap/Model/Url/RewriteTests/VehicleListTests/GeneratesURLS/MMYTest.php
@@ -21,7 +21,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Elite_Vafsitemap_Model_Url_RewriteTests_VehicleListTests_GeneratesURLS_MMYTest extends VF_TestCase
+class Elite_Vafsitemap_Model_Url_RewriteTests_VehicleListTests_GeneratesURLS_MMYTest extends Elite_TestCase
 {
 
     function doSetUp()

--- a/app/code/local/Elite/Vafsitemap/Model/Url/RewriteTests/VehicleListTests/RewritesURLS/VehicleListTest.php
+++ b/app/code/local/Elite/Vafsitemap/Model/Url/RewriteTests/VehicleListTests/RewritesURLS/VehicleListTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafsitemap_Model_Url_RewriteTests_VehicleListTests_RewritesURLS_VehicleListTest extends VF_TestCase
+class Elite_Vafsitemap_Model_Url_RewriteTests_VehicleListTests_RewritesURLS_VehicleListTest extends Elite_TestCase
 {
     function doSetUp()
     {

--- a/app/code/local/Elite/Vafsitemap/Model/Url/RewriteTests/VehicleProductPageTests/RewriteURLS/MMYTest.php
+++ b/app/code/local/Elite/Vafsitemap/Model/Url/RewriteTests/VehicleProductPageTests/RewriteURLS/MMYTest.php
@@ -81,7 +81,7 @@ class Elite_Vafsitemap_Model_Url_RewriteTests_VehicleProductPageTests_RewriteURL
 
 	$this->rewrite($request);
 
-	VF_Singleton::getInstance()->getProductIds();
+	Elite_Vaf_Singleton::getInstance()->getProductIds();
 	$this->assertEquals($vehicle->getLevel('make')->getId(), $_SESSION['make'], 'should look up the right ID#s from the vehicle string');
 	$this->assertEquals($vehicle->getLevel('model')->getId(), $_SESSION['model'], 'should look up the right ID#s from the vehicle string');
 	$this->assertEquals($vehicle->getLevel('year')->getId(), $_SESSION['year'], 'should look up the right ID#s from the vehicle string');
@@ -97,7 +97,7 @@ class Elite_Vafsitemap_Model_Url_RewriteTests_VehicleProductPageTests_RewriteURL
 	$config = new Zend_Config( array('seo'=>array('rewriteLevels'=>'make,model')) );
 	$this->rewrite($request, $config);
 
-	VF_Singleton::getInstance()->getProductIds();
+	Elite_Vaf_Singleton::getInstance()->getProductIds();
 	$this->assertEquals($vehicle->getLevel('make')->getId(), $_SESSION['make'], 'should look up the right ID#s from the vehicle string');
 	$this->assertEquals($vehicle->getLevel('model')->getId(), $_SESSION['model'], 'should look up the right ID#s from the vehicle string');
 	$this->assertEquals(0, $_SESSION['year'], 'should store a partial vehicle for custom levels');

--- a/app/code/local/Elite/Vafsitemap/controllers/Admin/VafsitemapController.php
+++ b/app/code/local/Elite/Vafsitemap/controllers/Admin/VafsitemapController.php
@@ -74,7 +74,7 @@ class Elite_Vafsitemap_Admin_VafsitemapController extends Mage_Adminhtml_Control
 
     function config()
     {
-	return VF_Singleton::getInstance()->getConfig();
+	return Elite_Vaf_Singleton::getInstance()->getConfig();
     }
 
     protected function checkVersion()

--- a/app/code/local/Elite/Vafsitemap/controllers/ProductController.php
+++ b/app/code/local/Elite/Vafsitemap/controllers/ProductController.php
@@ -26,7 +26,7 @@ class Elite_Vafsitemap_ProductController extends Mage_Core_Controller_Front_Acti
 {
     function indexAction()
     { 
-        if( !VF_Singleton::getInstance()->getConfig()->seo->htmlSitemap )
+        if( !Elite_Vaf_Singleton::getInstance()->getConfig()->seo->htmlSitemap )
         {
             return;
         }

--- a/app/code/local/Elite/Vafsitemap/controllers/VehicleController.php
+++ b/app/code/local/Elite/Vafsitemap/controllers/VehicleController.php
@@ -27,7 +27,7 @@ class Elite_Vafsitemap_VehicleController extends Mage_Core_Controller_Front_Acti
     /** Magento uses the "handle" of this action to load the block where the code lives */
     function indexAction()
     { 
-        if( !VF_Singleton::getInstance()->getConfig()->seo->htmlSitemap )
+        if( !Elite_Vaf_Singleton::getInstance()->getConfig()->seo->htmlSitemap )
         {
             return;
         }

--- a/app/code/local/Elite/Vafsitemap/etc/config.xml
+++ b/app/code/local/Elite/Vafsitemap/etc/config.xml
@@ -3,7 +3,7 @@
 <config>
     <modules>
         <Elite_Vafsitemap>
-            <version>v2-build44</version>
+            <version>v2.1-build1</version>
         </Elite_Vafsitemap>
     </modules>
     <global>

--- a/app/code/local/Elite/Vaftire/Model/Catalog/Product.php
+++ b/app/code/local/Elite/Vaftire/Model/Catalog/Product.php
@@ -140,7 +140,7 @@ class Elite_Vaftire_Model_Catalog_Product
     /** @return Zend_Db_Adapter_Abstract */
     protected function getReadAdapter()
     {
-        return VF_Singleton::getInstance()->getReadAdapter();
+        return Elite_Vaf_Singleton::getInstance()->getReadAdapter();
     }
 
 }

--- a/app/code/local/Elite/Vaftire/Model/Catalog/Product/Export.php
+++ b/app/code/local/Elite/Vaftire/Model/Catalog/Product/Export.php
@@ -51,7 +51,7 @@ class Elite_Vaftire_Model_Catalog_Product_Export
 
     function getProductRows()
     {
-	$query = VF_Singleton::getInstance()->getReadAdapter()->select()
+	$query = Elite_Vaf_Singleton::getInstance()->getReadAdapter()->select()
 		->from($this->getProductTable(), array('entity_id','sku'));
 	$rs = $query->query();
 	$ids = array();

--- a/app/code/local/Elite/Vaftire/Model/Catalog/Product/ExportTest.php
+++ b/app/code/local/Elite/Vaftire/Model/Catalog/Product/ExportTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaftire_Model_Catalog_Product_ExportTest extends VF_TestCase
+class Elite_Vaftire_Model_Catalog_Product_ExportTest extends Elite_TestCase
 {
 	function testExportHeaders()
 	{

--- a/app/code/local/Elite/Vaftire/Model/Catalog/Product/ImportTests/TestCase.php
+++ b/app/code/local/Elite/Vaftire/Model/Catalog/Product/ImportTests/TestCase.php
@@ -22,7 +22,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Elite_Vaftire_Model_Catalog_Product_ImportTests_TestCase extends VF_TestCase
+class Elite_Vaftire_Model_Catalog_Product_ImportTests_TestCase extends Elite_TestCase
 {
 
     function importer($file)

--- a/app/code/local/Elite/Vaftire/Model/Catalog/ProductTests/TireSizeTest.php
+++ b/app/code/local/Elite/Vaftire/Model/Catalog/ProductTests/TireSizeTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaftire_Model_Catalog_ProductTests_TireSizeTest extends VF_TestCase
+class Elite_Vaftire_Model_Catalog_ProductTests_TireSizeTest extends Elite_TestCase
 {
     const ID = 1;
     

--- a/app/code/local/Elite/Vaftire/Model/Catalog/ProductTests/TireTypeTest.php
+++ b/app/code/local/Elite/Vaftire/Model/Catalog/ProductTests/TireTypeTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaftire_Model_Catalog_ProductTests_TireTypeTest extends VF_TestCase
+class Elite_Vaftire_Model_Catalog_ProductTests_TireTypeTest extends Elite_TestCase
 {
 	function testNoTireType()
 	{

--- a/app/code/local/Elite/Vaftire/Model/Finder.php
+++ b/app/code/local/Elite/Vaftire/Model/Finder.php
@@ -88,6 +88,6 @@ class Elite_Vaftire_Model_Finder
     /** @return Zend_Db_Adapter_Abstract */
     protected function getReadAdapter()
     {
-        return VF_Singleton::getInstance()->getReadAdapter();
+        return Elite_Vaf_Singleton::getInstance()->getReadAdapter();
     }
 }

--- a/app/code/local/Elite/Vaftire/Model/FinderTests/AspectRatioTest.php
+++ b/app/code/local/Elite/Vaftire/Model/FinderTests/AspectRatioTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaftire_Model_FinderTests_AspectRatioTest extends VF_TestCase
+class Elite_Vaftire_Model_FinderTests_AspectRatioTest extends Elite_TestCase
 {
 	function testShouldFindAll()
     {

--- a/app/code/local/Elite/Vaftire/Model/FinderTests/DiameterTest.php
+++ b/app/code/local/Elite/Vaftire/Model/FinderTests/DiameterTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaftire_Model_FinderTests_DiameterTest extends VF_TestCase
+class Elite_Vaftire_Model_FinderTests_DiameterTest extends Elite_TestCase
 {
     function testShouldFindAll()
     {

--- a/app/code/local/Elite/Vaftire/Model/FinderTests/FilterTest.php
+++ b/app/code/local/Elite/Vaftire/Model/FinderTests/FilterTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaftire_Model_FinderTest extends VF_TestCase
+class Elite_Vaftire_Model_FinderTest extends Elite_TestCase
 {
     function testFindsProductBySize()
     {

--- a/app/code/local/Elite/Vaftire/Model/FinderTests/SectionWidthTest.php
+++ b/app/code/local/Elite/Vaftire/Model/FinderTests/SectionWidthTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaftire_Model_FinderTests_SectionWidthTest extends VF_TestCase
+class Elite_Vaftire_Model_FinderTests_SectionWidthTest extends Elite_TestCase
 {
     function testFindAll()
     {

--- a/app/code/local/Elite/Vaftire/Model/FlexibleSearch.php
+++ b/app/code/local/Elite/Vaftire/Model/FlexibleSearch.php
@@ -134,7 +134,7 @@ class Elite_Vaftire_Model_FlexibleSearch extends VF_FlexibleSearch_Wrapper imple
     {
 	if (!$this->config instanceof Zend_Config)
 	{
-	    $this->config = VF_Singleton::getInstance()->getConfig();
+	    $this->config = Elite_Vaf_Singleton::getInstance()->getConfig();
 	}
 	return $this->config;
     }

--- a/app/code/local/Elite/Vaftire/Model/FlexibleSearchTests/AspectRatioTest.php
+++ b/app/code/local/Elite/Vaftire/Model/FlexibleSearchTests/AspectRatioTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaftire_Model_FlexibleSearchTests_AspectRatioTest extends VF_TestCase
+class Elite_Vaftire_Model_FlexibleSearchTests_AspectRatioTest extends Elite_TestCase
 {
     function testShouldGetFromRequest()
     {
@@ -32,17 +32,17 @@ class Elite_Vaftire_Model_FlexibleSearchTests_AspectRatioTest extends VF_TestCas
     function testShouldStoreInSession()
     {
         $flexibleSearch = $this->flexibleTireSearch(array('section_width'=>'205', 'aspect_ratio'=>'55', 'diameter'=>'16'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         $this->assertEquals( 55, $this->flexibleTireSearch()->aspectRatio(), 'should store aspect ratio in session' );
     }
     
     function testShouldClearFromSession()
     {
         $flexibleSearch = $this->flexibleTireSearch(array('section_width'=>'205', 'aspect_ratio'=>'55', 'diameter'=>'16'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $flexibleSearch = $this->flexibleTireSearch(array('section_width'=>'0', 'aspect_ratio'=>'0', 'diameter'=>'0'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $this->assertNull( $this->flexibleTireSearch()->aspectRatio(), 'should clear aspect ratio from session' );
     }

--- a/app/code/local/Elite/Vaftire/Model/FlexibleSearchTests/DiameterTest.php
+++ b/app/code/local/Elite/Vaftire/Model/FlexibleSearchTests/DiameterTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaftire_Model_FlexibleSearchTests_DiameterTest extends VF_TestCase
+class Elite_Vaftire_Model_FlexibleSearchTests_DiameterTest extends Elite_TestCase
 {
     function testShouldGetFromRequest()
     {
@@ -32,17 +32,17 @@ class Elite_Vaftire_Model_FlexibleSearchTests_DiameterTest extends VF_TestCase
     function testShouldInSession()
     {
         $flexibleSearch = $this->flexibleTireSearch(array('section_width'=>'205', 'aspect_ratio'=>'55', 'diameter'=>'16'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         $this->assertEquals( 16, $this->flexibleTireSearch()->diameter(), 'should store diameter in session' );
 	}
 	
 	function testShouldClearFromSession()
     {
         $flexibleSearch = $this->flexibleTireSearch(array('section_width'=>'205', 'aspect_ratio'=>'55', 'diameter'=>'16'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $flexibleSearch = $this->flexibleTireSearch(array('section_width'=>'0', 'aspect_ratio'=>'0', 'diameter'=>'0'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $this->assertNull( $this->flexibleTireSearch()->diameter(), 'should clear diameter from session' );
     }

--- a/app/code/local/Elite/Vaftire/Model/FlexibleSearchTests/FilterBySizeTest.php
+++ b/app/code/local/Elite/Vaftire/Model/FlexibleSearchTests/FilterBySizeTest.php
@@ -22,7 +22,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Elite_Vaftire_Model_FlexibleSearchTests_FilterBySizeTest extends VF_TestCase
+class Elite_Vaftire_Model_FlexibleSearchTests_FilterBySizeTest extends Elite_TestCase
 {
 
     function testTireSearch()
@@ -58,7 +58,7 @@ class Elite_Vaftire_Model_FlexibleSearchTests_FilterBySizeTest extends VF_TestCa
 	$flexibleTireSearch = $this->flexibleTireSearch($tireParamaters);
 	$flexibleTireSearch->storeTireSizeInSession();
 
-	$this->assertEquals(array(1), VF_Singleton::getInstance()->flexibleSearch()->doGetProductIds(), 'should clear wheel search');
+	$this->assertEquals(array(1), Elite_Vaf_Singleton::getInstance()->flexibleSearch()->doGetProductIds(), 'should clear wheel search');
 	$this->assertEquals('', $this->flexibleWheelSearch()->boltPattern()->getLugCount(), 'should clear bolt pattern from session' );
     }
 
@@ -66,11 +66,11 @@ class Elite_Vaftire_Model_FlexibleSearchTests_FilterBySizeTest extends VF_TestCa
     {
 	$vehicle = $this->createVehicle(array('make'=>'Honda', 'model'=>'Civic', 'year'=>'2000'));
 	$this->setRequestParams($vehicle->toValueArray());
-	$this->assertEquals( $vehicle->toValueArray(), VF_Singleton::getInstance()->vehicleSelection()->toValueArray(), 'should first select a vehicle');
+	$this->assertEquals( $vehicle->toValueArray(), Elite_Vaf_Singleton::getInstance()->vehicleSelection()->toValueArray(), 'should first select a vehicle');
 
 	$this->setRequestParams(array('section_width' => '205', 'aspect_ratio' => '55', 'diameter' => '16'));
-	VF_Singleton::getInstance()->flexibleSearch()->doGetProductIds();
-	$this->assertNull(VF_Singleton::getInstance()->vehicleSelection()->getFirstVehicle(), 'should clear vehicle when searching on a tire size');
+	Elite_Vaf_Singleton::getInstance()->flexibleSearch()->doGetProductIds();
+	$this->assertNull(Elite_Vaf_Singleton::getInstance()->vehicleSelection()->getFirstVehicle(), 'should clear vehicle when searching on a tire size');
     }
 
 }

--- a/app/code/local/Elite/Vaftire/Model/FlexibleSearchTests/FilterByTypeTest.php
+++ b/app/code/local/Elite/Vaftire/Model/FlexibleSearchTests/FilterByTypeTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaftire_Model_FlexibleSearchTests_FilterByTypeTest extends VF_TestCase
+class Elite_Vaftire_Model_FlexibleSearchTests_FilterByTypeTest extends Elite_TestCase
 {
 	function testFilterByType()
     {

--- a/app/code/local/Elite/Vaftire/Model/FlexibleSearchTests/PreselectTest.php
+++ b/app/code/local/Elite/Vaftire/Model/FlexibleSearchTests/PreselectTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaftire_Model_FlexibleSearchTests extends VF_TestCase
+class Elite_Vaftire_Model_FlexibleSearchTests extends Elite_TestCase
 {
 
     function doSetUp()

--- a/app/code/local/Elite/Vaftire/Model/FlexibleSearchTests/SectionWidthTest.php
+++ b/app/code/local/Elite/Vaftire/Model/FlexibleSearchTests/SectionWidthTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaftire_Model_FlexibleSearchTests_SectionWidthTest extends VF_TestCase
+class Elite_Vaftire_Model_FlexibleSearchTests_SectionWidthTest extends Elite_TestCase
 {
     function testShouldGetFromRequest()
     {
@@ -32,17 +32,17 @@ class Elite_Vaftire_Model_FlexibleSearchTests_SectionWidthTest extends VF_TestCa
     function testShouldStoreInSession()
     {
         $flexibleSearch = $this->flexibleTireSearch(array('section_width'=>'205', 'aspect_ratio'=>'55', 'diameter'=>'16'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         $this->assertEquals( 205, $this->flexibleTireSearch()->sectionWidth(), 'should store section width in session' );
     }
     
     function testShouldClearFromSession()
     {
         $flexibleSearch = $this->flexibleTireSearch(array('section_width'=>'205', 'aspect_ratio'=>'55', 'diameter'=>'16'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $flexibleSearch = $this->flexibleTireSearch(array('section_width'=>'0', 'aspect_ratio'=>'0', 'diameter'=>'0'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $this->assertNull( $this->flexibleTireSearch()->sectionWidth(), 'should clear section width from session' );
     }

--- a/app/code/local/Elite/Vaftire/Model/FlexibleSearchTests/TypeTest.php
+++ b/app/code/local/Elite/Vaftire/Model/FlexibleSearchTests/TypeTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaftire_Model_FlexibleSearchTests_TypeTest extends VF_TestCase
+class Elite_Vaftire_Model_FlexibleSearchTests_TypeTest extends Elite_TestCase
 {
 	function testShouldGetFromRequest()
     {
@@ -32,17 +32,17 @@ class Elite_Vaftire_Model_FlexibleSearchTests_TypeTest extends VF_TestCase
     function testShouldStoreInSession()
     {
         $flexibleSearch = $this->flexibleTireSearch(array('tire_type'=>2,'section_width'=>'205', 'aspect_ratio'=>'55', 'diameter'=>'16'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         $this->assertEquals( 2, $this->flexibleTireSearch(array())->tireType(), 'should store tire type in session' );
     }
     
     function testShouldClearFromSession()
     {
         $flexibleSearch = $this->flexibleTireSearch(array('tire_type'=>2,'section_width'=>'205', 'aspect_ratio'=>'55', 'diameter'=>'16'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $flexibleSearch = $this->flexibleTireSearch(array('tire_type'=>'','section_width'=>'0', 'aspect_ratio'=>'0', 'diameter'=>'0'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $this->assertNull( $this->flexibleTireSearch()->tireType(), 'should clear tire type from session' );
     }
@@ -50,10 +50,10 @@ class Elite_Vaftire_Model_FlexibleSearchTests_TypeTest extends VF_TestCase
     function testShouldClearFromSession2()
     {
         $flexibleSearch = $this->flexibleTireSearch(array('tire_type'=>2,'section_width'=>'205', 'aspect_ratio'=>'55', 'diameter'=>'16'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $flexibleSearch = $this->flexibleTireSearch(array('tire_type'=>'','section_width'=>'0', 'aspect_ratio'=>'0', 'diameter'=>'0'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $this->assertNull( $flexibleSearch->tireType(), 'should clear tire type from session' );
     }

--- a/app/code/local/Elite/Vaftire/Model/Importer/Definitions/TireSizeTests/MMY/TestCase.php
+++ b/app/code/local/Elite/Vaftire/Model/Importer/Definitions/TireSizeTests/MMY/TestCase.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaftire_Model_Importer_Definitions_TireSizeTests_MMY_TestCase extends VF_TestCase
+class Elite_Vaftire_Model_Importer_Definitions_TireSizeTests_MMY_TestCase extends Elite_TestCase
 {
     function importVehicleTireSizes($stringData)
     {

--- a/app/code/local/Elite/Vaftire/Model/TireSizeTests/ConstructorTest.php
+++ b/app/code/local/Elite/Vaftire/Model/TireSizeTests/ConstructorTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaftire_Model_TireSizeTests_ConstructorTest extends VF_TestCase
+class Elite_Vaftire_Model_TireSizeTests_ConstructorTest extends Elite_TestCase
 {
     function testSectionWidth()
     {

--- a/app/code/local/Elite/Vaftire/Model/TireSizeTests/FormattedStringTest.php
+++ b/app/code/local/Elite/Vaftire/Model/TireSizeTests/FormattedStringTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaftire_Model_TireSizeTests_FormattedStringTest extends VF_TestCase
+class Elite_Vaftire_Model_TireSizeTests_FormattedStringTest extends Elite_TestCase
 {
     
     function testShouldCreateFromFormattedString()

--- a/app/code/local/Elite/Vaftire/Model/Vehicle.php
+++ b/app/code/local/Elite/Vaftire/Model/Vehicle.php
@@ -91,6 +91,6 @@ class Elite_Vaftire_Model_Vehicle
     /** @return Zend_Db_Adapter_Abstract */
     protected function getReadAdapter()
     {
-        return VF_Singleton::getInstance()->getReadAdapter();
+        return Elite_Vaf_Singleton::getInstance()->getReadAdapter();
     }
 }

--- a/app/code/local/Elite/Vaftire/Observer/ProductTireSizeBinder.php
+++ b/app/code/local/Elite/Vaftire/Observer/ProductTireSizeBinder.php
@@ -70,6 +70,6 @@ class Elite_Vaftire_Observer_ProductTireSizeBinder
     /** @return Zend_Db_Adapter_Abstract */
     protected function getReadAdapter()
     {
-        return VF_Singleton::getInstance()->getReadAdapter();
+        return Elite_Vaf_Singleton::getInstance()->getReadAdapter();
     }
 }

--- a/app/code/local/Elite/Vaftire/Observer/ProductTireSizeBinderTest.php
+++ b/app/code/local/Elite/Vaftire/Observer/ProductTireSizeBinderTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vaftire_Observer_ProductTireSizeBinderTest extends VF_TestCase
+class Elite_Vaftire_Observer_ProductTireSizeBinderTest extends Elite_TestCase
 {
     const ID = 1;
     

--- a/app/code/local/Elite/Vaftire/etc/config.xml
+++ b/app/code/local/Elite/Vaftire/etc/config.xml
@@ -4,7 +4,7 @@
     
     <modules>
         <Elite_Vaftire>
-            <version>v2-build44</version>
+            <version>v2.1-build1</version>
         </Elite_Vaftire>
     </modules>
     

--- a/app/code/local/Elite/Vaftire/migrations/13_addtiretype.php
+++ b/app/code/local/Elite/Vaftire/migrations/13_addtiretype.php
@@ -21,5 +21,5 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-$db = VF_Singleton::getInstance()->getReadAdapter();
+$db = Elite_Vaf_Singleton::getInstance()->getReadAdapter();
 $db->query("ALTER TABLE `elite_product_tire` ADD `tire_type` INT( 1 ) NOT NULL");

--- a/app/code/local/Elite/Vaftire/migrations/14_add_vehicle_tiretype.php
+++ b/app/code/local/Elite/Vaftire/migrations/14_add_vehicle_tiretype.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-$db = VF_Singleton::getInstance()->getReadAdapter();
+$db = Elite_Vaf_Singleton::getInstance()->getReadAdapter();
 
 $db->query("
 CREATE TABLE IF NOT EXISTS `elite_vehicle_tire` (

--- a/app/code/local/Elite/Vaftire/migrations/9_add_product_tire_tbl.php
+++ b/app/code/local/Elite/Vaftire/migrations/9_add_product_tire_tbl.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-$db = VF_Singleton::getInstance()->getReadAdapter();
+$db = Elite_Vaf_Singleton::getInstance()->getReadAdapter();
 $db->query("CREATE TABLE `elite_product_tire` (
     `entity_id` INT( 50 ) NOT NULL ,
     `section_width` INT( 3 ) NOT NULL ,

--- a/app/code/local/Elite/Vafwheel/Model/BoltPatternTest.php
+++ b/app/code/local/Elite/Vafwheel/Model/BoltPatternTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafwheel_Model_BoltPatternTest extends VF_TestCase
+class Elite_Vafwheel_Model_BoltPatternTest extends Elite_TestCase
 {
     
     function testSingleToString()

--- a/app/code/local/Elite/Vafwheel/Model/Catalog/Product.php
+++ b/app/code/local/Elite/Vafwheel/Model/Catalog/Product.php
@@ -137,6 +137,6 @@ class Elite_Vafwheel_Model_Catalog_Product
     /** @return Zend_Db_Adapter_Abstract */
     protected function getReadAdapter()
     {
-        return VF_Singleton::getInstance()->getReadAdapter();
+        return Elite_Vaf_Singleton::getInstance()->getReadAdapter();
     }
 }

--- a/app/code/local/Elite/Vafwheel/Model/Catalog/ProductTest.php
+++ b/app/code/local/Elite/Vafwheel/Model/Catalog/ProductTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafwheel_Model_Catalog_ProductTest extends VF_TestCase
+class Elite_Vafwheel_Model_Catalog_ProductTest extends Elite_TestCase
 { 
     function testCreateNewProduct()
     {

--- a/app/code/local/Elite/Vafwheel/Model/Finder.php
+++ b/app/code/local/Elite/Vafwheel/Model/Finder.php
@@ -67,6 +67,6 @@ class Elite_Vafwheel_Model_Finder
     /** @return Zend_Db_Adapter_Abstract */
     protected function getReadAdapter()
     {
-        return VF_Singleton::getInstance()->getReadAdapter();
+        return Elite_Vaf_Singleton::getInstance()->getReadAdapter();
     }
 }

--- a/app/code/local/Elite/Vafwheel/Model/FinderTest.php
+++ b/app/code/local/Elite/Vafwheel/Model/FinderTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafwheel_Model_FinderTest extends VF_TestCase
+class Elite_Vafwheel_Model_FinderTest extends Elite_TestCase
 {
     function testFindsPossibleLugCount()
     {

--- a/app/code/local/Elite/Vafwheel/Model/FlexibleSearchTests/LugCountTest.php
+++ b/app/code/local/Elite/Vafwheel/Model/FlexibleSearchTests/LugCountTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafwheel_Model_FlexibleSearchTests_LugCountTest extends VF_TestCase
+class Elite_Vafwheel_Model_FlexibleSearchTests_LugCountTest extends Elite_TestCase
 {
 	function testShouldGetFromRequest()
     {
@@ -32,17 +32,17 @@ class Elite_Vafwheel_Model_FlexibleSearchTests_LugCountTest extends VF_TestCase
     function testShouldStoreInSession()
     {
         $flexibleSearch = $this->flexibleWheelSearch(array('lug_count'=>'5'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         $this->assertEquals( 5, $this->flexibleWheelSearch()->lugCount(), 'should store lug count in session' );
     }
     
     function testShouldClearFromSession()
     {
         $flexibleSearch = $this->flexibleWheelSearch(array('lug_count'=>'5'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $flexibleSearch = $this->flexibleWheelSearch(array('lug_count'=>'0'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $this->assertEquals( 0, $this->flexibleWheelSearch()->lugCount(), 'should clear lug count from session' );
     }

--- a/app/code/local/Elite/Vafwheel/Model/FlexibleSearchTests/StudSpreadTest.php
+++ b/app/code/local/Elite/Vafwheel/Model/FlexibleSearchTests/StudSpreadTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafwheel_Model_FlexibleSearchTests_StudSpreadTest extends VF_TestCase
+class Elite_Vafwheel_Model_FlexibleSearchTests_StudSpreadTest extends Elite_TestCase
 {
 	function testShouldGetFromRequest()
     {
@@ -32,17 +32,17 @@ class Elite_Vafwheel_Model_FlexibleSearchTests_StudSpreadTest extends VF_TestCas
     function testShouldStoreInSession()
     {
         $flexibleSearch = $this->flexibleWheelSearch(array('stud_spread'=>'114.3'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         $this->assertEquals( 114.3, $this->flexibleWheelSearch()->studSpread(), 'should store stud spread in session' );
     }
     
     function testShouldClearFromSession()
     {
         $flexibleSearch = $this->flexibleWheelSearch(array('stud_spread'=>'5'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $flexibleSearch = $this->flexibleWheelSearch(array('stud_spread'=>'0'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $this->assertEquals( 0, $this->flexibleWheelSearch()->studSpread(), 'should clear stud spread from session' );
     }

--- a/app/code/local/Elite/Vafwheel/Model/FlexibleSearchTests/VehicleSearchTest.php
+++ b/app/code/local/Elite/Vafwheel/Model/FlexibleSearchTests/VehicleSearchTest.php
@@ -22,7 +22,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Elite_Vafwheel_Model_FlexibleSearchTests_VehicleSearchTest extends VF_TestCase
+class Elite_Vafwheel_Model_FlexibleSearchTests_VehicleSearchTest extends Elite_TestCase
 {
 
     /** @var VF_Vehicle */

--- a/app/code/local/Elite/Vafwheel/Model/FlexibleSearchTests/WheelSearchTest.php
+++ b/app/code/local/Elite/Vafwheel/Model/FlexibleSearchTests/WheelSearchTest.php
@@ -22,7 +22,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Elite_Vafwheel_Model_FlexibleSearchTests_WheelSearchTest extends VF_TestCase
+class Elite_Vafwheel_Model_FlexibleSearchTests_WheelSearchTest extends Elite_TestCase
 {
 
     function testShouldFindMatchingWheels()
@@ -56,7 +56,7 @@ class Elite_Vafwheel_Model_FlexibleSearchTests_WheelSearchTest extends VF_TestCa
 	$flexibleWheelSearch = $this->flexibleWheelSearch($wheelParamaters);
 	$flexibleWheelSearch->storeSizeInSession();
 	
-	$this->assertEquals(array(1), VF_Singleton::getInstance()->flexibleSearch()->doGetProductIds(), 'should clear tire search');
+	$this->assertEquals(array(1), Elite_Vaf_Singleton::getInstance()->flexibleSearch()->doGetProductIds(), 'should clear tire search');
 	$this->assertNull( $this->flexibleTireSearch()->aspectRatio(), 'should clear aspect ratio from session' );
     }
 
@@ -64,11 +64,11 @@ class Elite_Vafwheel_Model_FlexibleSearchTests_WheelSearchTest extends VF_TestCa
     {
 	$vehicle = $this->createVehicle(array('make'=>'Honda', 'model'=>'Civic', 'year'=>'2000'));
 	$this->setRequestParams($vehicle->toValueArray());
-	$this->assertEquals( $vehicle->toValueArray(), VF_Singleton::getInstance()->vehicleSelection()->toValueArray(), 'should first select a vehicle');
+	$this->assertEquals( $vehicle->toValueArray(), Elite_Vaf_Singleton::getInstance()->vehicleSelection()->toValueArray(), 'should first select a vehicle');
 
 	$this->setRequestParams(array('lug_count' => '5', 'stud_spread' => '114.3'));
-	VF_Singleton::getInstance()->flexibleSearch()->doGetProductIds();
-	$this->assertNull(VF_Singleton::getInstance()->vehicleSelection()->getFirstVehicle(), 'should clear vehicle when searching on a wheel size');
+	Elite_Vaf_Singleton::getInstance()->flexibleSearch()->doGetProductIds();
+	$this->assertNull(Elite_Vaf_Singleton::getInstance()->vehicleSelection()->getFirstVehicle(), 'should clear vehicle when searching on a wheel size');
     }
 
 }

--- a/app/code/local/Elite/Vafwheel/Model/Importer/Definitions/BoltsTests/TestCase.php
+++ b/app/code/local/Elite/Vafwheel/Model/Importer/Definitions/BoltsTests/TestCase.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-abstract class Elite_Vafwheel_Model_Importer_Definitions_BoltsTests_TestCase extends VF_TestCase
+abstract class Elite_Vafwheel_Model_Importer_Definitions_BoltsTests_TestCase extends Elite_TestCase
 {
     function importVehicleBolts($stringData)
     {

--- a/app/code/local/Elite/Vafwheel/Model/Vehicle.php
+++ b/app/code/local/Elite/Vafwheel/Model/Vehicle.php
@@ -71,6 +71,6 @@ class Elite_Vafwheel_Model_Vehicle
     /** @return Zend_Db_Adapter_Abstract */
     protected function getReadAdapter()
     {
-        return VF_Singleton::getInstance()->getReadAdapter();
+        return Elite_Vaf_Singleton::getInstance()->getReadAdapter();
     }
 }

--- a/app/code/local/Elite/Vafwheel/Observer/ProductBoltBinderTest.php
+++ b/app/code/local/Elite/Vafwheel/Observer/ProductBoltBinderTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafwheel_Observer_ProductBoltBinderTest extends VF_TestCase
+class Elite_Vafwheel_Observer_ProductBoltBinderTest extends Elite_TestCase
 {
     function doSetUp()
     {

--- a/app/code/local/Elite/Vafwheel/cron/product-wheel-sizes-import.csvTest.php
+++ b/app/code/local/Elite/Vafwheel/cron/product-wheel-sizes-import.csvTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class product_wheel_sizes_import_csvTest extends VF_TestCase
+class product_wheel_sizes_import_csvTest extends Elite_TestCase
 {
     function testTest()
     {

--- a/app/code/local/Elite/Vafwheel/etc/config.xml
+++ b/app/code/local/Elite/Vafwheel/etc/config.xml
@@ -4,7 +4,7 @@
     
     <modules>
         <Elite_Vafwheel>
-            <version>v2-build44</version>
+            <version>v2.1-build1</version>
         </Elite_Vafwheel>
     </modules>
     

--- a/app/code/local/Elite/Vafwheel/migrations/10_rename_bolt_pattern_tbl.php
+++ b/app/code/local/Elite/Vafwheel/migrations/10_rename_bolt_pattern_tbl.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-$db = VF_Singleton::getInstance()->getReadAdapter();
+$db = Elite_Vaf_Singleton::getInstance()->getReadAdapter();
 $query = "RENAME TABLE elite_mapping_bolt_pattern to elite_definition_wheel;";
 $db->query( $query );
 

--- a/app/code/local/Elite/Vafwheel/migrations/11_add_product_wheel_tbl.php
+++ b/app/code/local/Elite/Vafwheel/migrations/11_add_product_wheel_tbl.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-$db = VF_Singleton::getInstance()->getReadAdapter();
+$db = Elite_Vaf_Singleton::getInstance()->getReadAdapter();
 $db->query("CREATE TABLE IF NOT EXISTS `elite_product_wheel` (
   `entity_id` int(50) NOT NULL,
   `lug_count` int(1) NOT NULL,

--- a/app/code/local/Elite/Vafwheel/migrations/24_add_offset.php
+++ b/app/code/local/Elite/Vafwheel/migrations/24_add_offset.php
@@ -26,7 +26,7 @@ class Vaf24
     function run()
     {
         $schema = new VF_Schema();
-        $db = VF_Singleton::getInstance()->getReadAdapter();
+        $db = Elite_Vaf_Singleton::getInstance()->getReadAdapter();
         foreach($schema->getLevels() as $level)
         {
             $db->query('ALTER TABLE `elite_product_wheel` ADD `offset` FLOAT NOT NULL ');

--- a/app/code/local/Elite/Vafwheeladapter/Model/Catalog/ProductTest.php
+++ b/app/code/local/Elite/Vafwheeladapter/Model/Catalog/ProductTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafwheeladapter_Model_Catalog_ProductTest extends VF_TestCase
+class Elite_Vafwheeladapter_Model_Catalog_ProductTest extends Elite_TestCase
 { 
     function testCreateNewProduct()
     {

--- a/app/code/local/Elite/Vafwheeladapter/Model/Finder.php
+++ b/app/code/local/Elite/Vafwheeladapter/Model/Finder.php
@@ -108,6 +108,6 @@ class Elite_Vafwheeladapter_Model_Finder
     /** @return Zend_Db_Adapter_Abstract */
     protected function getReadAdapter()
     {
-        return VF_Singleton::getInstance()->getReadAdapter();
+        return Elite_Vaf_Singleton::getInstance()->getReadAdapter();
     }
 }

--- a/app/code/local/Elite/Vafwheeladapter/Model/FinderTests/FindsProductsTest.php
+++ b/app/code/local/Elite/Vafwheeladapter/Model/FinderTests/FindsProductsTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafwheeladapter_Model_FinderTests_FindsProductsTest extends VF_TestCase
+class Elite_Vafwheeladapter_Model_FinderTests_FindsProductsTest extends Elite_TestCase
 {
 	function testFindsMatchingProductForVehicleSide()
     {

--- a/app/code/local/Elite/Vafwheeladapter/Model/FinderTests/FindsVehicleSideTest.php
+++ b/app/code/local/Elite/Vafwheeladapter/Model/FinderTests/FindsVehicleSideTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafwheeladapter_Model_FinderTests_FindsVehicleSideTest extends VF_TestCase
+class Elite_Vafwheeladapter_Model_FinderTests_FindsVehicleSideTest extends Elite_TestCase
 {
 	function testShouldFindLugCount()
     {

--- a/app/code/local/Elite/Vafwheeladapter/Model/FinderTests/FindsWheelSideTest.php
+++ b/app/code/local/Elite/Vafwheeladapter/Model/FinderTests/FindsWheelSideTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafwheeladapter_Model_FinderTests_FindsWheelSideTest extends VF_TestCase
+class Elite_Vafwheeladapter_Model_FinderTests_FindsWheelSideTest extends Elite_TestCase
 {
     function testFindsLugCount()
     {

--- a/app/code/local/Elite/Vafwheeladapter/Model/FinderTests/SortsVehicleSideTest.php
+++ b/app/code/local/Elite/Vafwheeladapter/Model/FinderTests/SortsVehicleSideTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafwheeladapter_Model_FinderTests_SortsVehicleSideTest extends VF_TestCase
+class Elite_Vafwheeladapter_Model_FinderTests_SortsVehicleSideTest extends Elite_TestCase
 {
 	function testShouldSortLugCount()
     {

--- a/app/code/local/Elite/Vafwheeladapter/Model/FinderTests/SortsWheelSideTest.php
+++ b/app/code/local/Elite/Vafwheeladapter/Model/FinderTests/SortsWheelSideTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafwheeladapter_Model_FinderTests_SortsWheelSideTest extends VF_TestCase
+class Elite_Vafwheeladapter_Model_FinderTests_SortsWheelSideTest extends Elite_TestCase
 {
 	function testShouldSortLugCount()
     {

--- a/app/code/local/Elite/Vafwheeladapter/Model/FlexibleSearchTests/FilterTest.php
+++ b/app/code/local/Elite/Vafwheeladapter/Model/FlexibleSearchTests/FilterTest.php
@@ -22,7 +22,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Elite_Vafwheeladapter_Model_FlexibleSearchTests_FilterTest extends VF_TestCase
+class Elite_Vafwheeladapter_Model_FlexibleSearchTests_FilterTest extends Elite_TestCase
 {
 
     function testNoSelection()

--- a/app/code/local/Elite/Vafwheeladapter/Model/FlexibleSearchTests/FilterTests/VehicleSideTest.php
+++ b/app/code/local/Elite/Vafwheeladapter/Model/FlexibleSearchTests/FilterTests/VehicleSideTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafwheeladapter_Model_FlexibleSearchTests_FilterTests_VehicleSideTest extends VF_TestCase
+class Elite_Vafwheeladapter_Model_FlexibleSearchTests_FilterTests_VehicleSideTest extends Elite_TestCase
 {
 	function testShouldFilterOnVehicleSide()
     {

--- a/app/code/local/Elite/Vafwheeladapter/Model/FlexibleSearchTests/FilterTests/WheelSideTest.php
+++ b/app/code/local/Elite/Vafwheeladapter/Model/FlexibleSearchTests/FilterTests/WheelSideTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafwheeladapter_Model_FlexibleSearchTests_FilterTests_WheelSideTest extends VF_TestCase
+class Elite_Vafwheeladapter_Model_FlexibleSearchTests_FilterTests_WheelSideTest extends Elite_TestCase
 {
 	function testShouldFilterOnWheelSide()
     {

--- a/app/code/local/Elite/Vafwheeladapter/Model/FlexibleSearchTests/VehicleSideLugCountTest.php
+++ b/app/code/local/Elite/Vafwheeladapter/Model/FlexibleSearchTests/VehicleSideLugCountTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafwheeladapter_Model_FlexibleSearchTests_VehicleSideLugCountTest extends VF_TestCase
+class Elite_Vafwheeladapter_Model_FlexibleSearchTests_VehicleSideLugCountTest extends Elite_TestCase
 {
 	function testShouldGetFromRequest()
     {
@@ -32,17 +32,17 @@ class Elite_Vafwheeladapter_Model_FlexibleSearchTests_VehicleSideLugCountTest ex
     function testShouldStoreInSession()
     {
         $flexibleSearch = $this->flexibleWheeladapterSearch(array('vehicle_lug_count'=>'5'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         $this->assertEquals( 5, $this->flexibleWheeladapterSearch()->vehicleSideLugCount(), 'should store vehicle side lug count in session' );
     }
     
     function testShouldClearFromSession()
     {
         $flexibleSearch = $this->flexibleWheeladapterSearch(array('vehicle_lug_count'=>'5'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $flexibleSearch = $this->flexibleWheeladapterSearch(array('vehicle_lug_count'=>'0'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $this->assertNull( $this->flexibleWheeladapterSearch()->vehicleSideLugCount(), 'should clear vehicle side lug count from session' );
     }

--- a/app/code/local/Elite/Vafwheeladapter/Model/FlexibleSearchTests/VehicleSideSpreadTest.php
+++ b/app/code/local/Elite/Vafwheeladapter/Model/FlexibleSearchTests/VehicleSideSpreadTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafwheeladapter_Model_FlexibleSearchTests_VehicleSideSpreadTest extends VF_TestCase
+class Elite_Vafwheeladapter_Model_FlexibleSearchTests_VehicleSideSpreadTest extends Elite_TestCase
 {
 	function testShouldGetFromRequest()
     {
@@ -32,17 +32,17 @@ class Elite_Vafwheeladapter_Model_FlexibleSearchTests_VehicleSideSpreadTest exte
     function testShouldStoreInSession()
     {
         $flexibleSearch = $this->flexibleWheeladapterSearch(array('vehicle_stud_spread'=>'5'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         $this->assertEquals( 5, $this->flexibleWheeladapterSearch()->vehicleSideStudSpread(), 'should store vehicle side stud spread in session' );
     }
     
     function testShouldClearFromSession()
     {
         $flexibleSearch = $this->flexibleWheeladapterSearch(array('vehicle_stud_spread'=>'5'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $flexibleSearch = $this->flexibleWheeladapterSearch(array('vehicle_stud_spread'=>'0'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $this->assertNull( $this->flexibleWheeladapterSearch()->vehicleSideStudSpread(), 'should clear vehicle side stud spread from session' );
     }

--- a/app/code/local/Elite/Vafwheeladapter/Model/FlexibleSearchTests/WheelSideLugCountTest.php
+++ b/app/code/local/Elite/Vafwheeladapter/Model/FlexibleSearchTests/WheelSideLugCountTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafwheeladapter_Model_FlexibleSearchTests_WheelSideLugCountTest extends VF_TestCase
+class Elite_Vafwheeladapter_Model_FlexibleSearchTests_WheelSideLugCountTest extends Elite_TestCase
 {
 	function testShouldGetFromRequest()
     {
@@ -32,17 +32,17 @@ class Elite_Vafwheeladapter_Model_FlexibleSearchTests_WheelSideLugCountTest exte
     function testShouldStoreInSession()
     {
         $flexibleSearch = $this->flexibleWheeladapterSearch(array('wheel_lug_count'=>'5'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         $this->assertEquals( 5, $this->flexibleWheeladapterSearch()->wheelSideLugCount(), 'should store wheel side lug count in session' );
     }
     
     function testShouldClearFromSession()
     {
         $flexibleSearch = $this->flexibleWheeladapterSearch(array('wheel_lug_count'=>'5'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $flexibleSearch = $this->flexibleWheeladapterSearch(array('wheel_lug_count'=>'0'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $this->assertNull( $this->flexibleWheeladapterSearch()->wheelSideLugCount(), 'should clear wheel side lug count from session' );
     }

--- a/app/code/local/Elite/Vafwheeladapter/Model/FlexibleSearchTests/WheelSideSpreadTest.php
+++ b/app/code/local/Elite/Vafwheeladapter/Model/FlexibleSearchTests/WheelSideSpreadTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafwheeladapter_Model_FlexibleSearchTests_WheelSideSpreadTest extends VF_TestCase
+class Elite_Vafwheeladapter_Model_FlexibleSearchTests_WheelSideSpreadTest extends Elite_TestCase
 {
 	function testShouldGetFromRequest()
     {
@@ -32,17 +32,17 @@ class Elite_Vafwheeladapter_Model_FlexibleSearchTests_WheelSideSpreadTest extend
     function testShouldStoreInSession()
     {
         $flexibleSearch = $this->flexibleWheeladapterSearch(array('wheel_stud_spread'=>'114.3'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         $this->assertEquals( 114.3, $this->flexibleWheeladapterSearch()->wheelSideStudSpread(), 'should store wheel side stud spread in session' );
     }
     
     function testShouldClearFromSession()
     {
         $flexibleSearch = $this->flexibleWheeladapterSearch(array('wheel_stud_spread'=>'114.3'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $flexibleSearch = $this->flexibleWheeladapterSearch(array('wheel_stud_spread'=>'0'));
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $this->assertNull( $this->flexibleWheeladapterSearch()->wheelSideStudSpread(), 'should clear wheel side stud spread from session' );
     }

--- a/app/code/local/Elite/Vafwheeladapter/Observer/WheelSideBinderTest.php
+++ b/app/code/local/Elite/Vafwheeladapter/Observer/WheelSideBinderTest.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Elite_Vafwheeladapter_Observer_WheelSideBinderTest extends VF_TestCase
+class Elite_Vafwheeladapter_Observer_WheelSideBinderTest extends Elite_TestCase
 {
     function doSetUp()
     {

--- a/app/code/local/Elite/Vafwheeladapter/etc/config.xml
+++ b/app/code/local/Elite/Vafwheeladapter/etc/config.xml
@@ -4,7 +4,7 @@
 
     <modules>
         <Elite_Vafwheeladapter>
-            <version>v2-build44</version>
+            <version>v2.1-build1</version>
         </Elite_Vafwheeladapter>
     </modules>
 

--- a/app/code/local/Elite/Vafwheeladapter/migrations/15_add_product_wheel_adapter_tbl.php
+++ b/app/code/local/Elite/Vafwheeladapter/migrations/15_add_product_wheel_adapter_tbl.php
@@ -21,7 +21,7 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-$db = VF_Singleton::getInstance()->getReadAdapter();
+$db = Elite_Vaf_Singleton::getInstance()->getReadAdapter();
 
 $db->query("CREATE TABLE IF NOT EXISTS `elite_product_wheeladapter` (
   `entity_id` int(50) NOT NULL,

--- a/app/code/local/Elite/bin/vfmagentoTest.php
+++ b/app/code/local/Elite/bin/vfmagentoTest.php
@@ -21,19 +21,19 @@
  * @copyright  Copyright (c) 2013 Vehicle Fits, llc
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class vfmagentoTest extends VF_TestCase
+class vfmagentoTest extends Elite_TestCase
 {
     function setUp()
     {
-        VF_Singleton::reset();
-        VF_Singleton::getInstance(true);
-        VF_Singleton::getInstance()->setRequest(new Zend_Controller_Request_Http);
+        Elite_Vaf_Singleton::reset();
+        Elite_Vaf_Singleton::getInstance(true);
+        Elite_Vaf_Singleton::getInstance()->setRequest(new Zend_Controller_Request_Http);
         $database = new VF_TestDbAdapter(array(
             'dbname' => VAF_DB_NAME,
             'username' => VAF_DB_USERNAME,
             'password' => VAF_DB_PASSWORD
         ));
-        VF_Singleton::getInstance()->setReadAdapter($database);
+        Elite_Vaf_Singleton::getInstance()->setReadAdapter($database);
 
         $schemaGenerator = new VF_Schema_Generator();
         $schemaGenerator->dropExistingTables();

--- a/app/code/local/Elite/composer.json
+++ b/app/code/local/Elite/composer.json
@@ -12,7 +12,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "vehiclefits/vehicle-fits-core": "0.2.*",
+        "vehiclefits/vehicle-fits-core": ">=0.2.2",
         "joshribakoff/zf1-empty": "*"
     },
     "require-dev": {

--- a/app/code/local/Elite/composer.json
+++ b/app/code/local/Elite/composer.json
@@ -25,7 +25,7 @@
     },
     "extras": {
         "branch-alias": {
-            "dev-master": "2.0.x-dev"
+            "dev-master": "2.1.x-dev"
         }
     }
 }

--- a/app/design/adminhtml/default/default/template/vf/catalog/product/tab/vaf.phtml
+++ b/app/design/adminhtml/default/default/template/vf/catalog/product/tab/vaf.phtml
@@ -82,7 +82,7 @@
                 <?php
                 foreach( $this->getFits() as $fit )
                 {
-                    $leafLevel = VF_Singleton::getInstance()->getLeafLevel();
+                    $leafLevel = Elite_Vaf_Singleton::getInstance()->getLeafLevel();
                     ?>
                     <div class="multiTree-selection">
                         <input type="checkbox" name="vafcheck[]" class="vafcheck" value="<?php echo $leafLevel?>-<?php echo $fit->id?>" />

--- a/app/design/frontend/base/default/template/vf/vaf/choosepaint.phtml
+++ b/app/design/frontend/base/default/template/vf/vaf/choosepaint.phtml
@@ -24,7 +24,7 @@ if(!isPainted($product))
 
 <div class="paintOptions" align="center">
     <?php
-    $fit = VF_Singleton::getInstance()->vehicleSelection();
+    $fit = Elite_Vaf_Singleton::getInstance()->vehicleSelection();
     if( $fit )
     {
     	$leaf_id = $fit->getLeafValue();

--- a/app/design/frontend/base/default/template/vf/vaf/group3/result.phtml
+++ b/app/design/frontend/base/default/template/vf/vaf/group3/result.phtml
@@ -2,7 +2,7 @@
 <?php
 $_coreHelper = $this->helper('core');
 
-$vehicle = VF_Singleton::getInstance()->vehicleSelection();
+$vehicle = Elite_Vaf_Singleton::getInstance()->vehicleSelection();
 $vehicle = new Elite_Vafdiagram_Model_Vehicle($vehicle);
 $serviceCode = $vehicle->serviceCode();
 ?>

--- a/app/design/frontend/base/default/template/vf/vaf/search.phtml
+++ b/app/design/frontend/base/default/template/vf/vaf/search.phtml
@@ -2,7 +2,7 @@
     <div class="head"><h4><?=$this->getHeaderText()?></h4></div>
     <div class="content">                            
     	<?php
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         ?>
     	<?=$this->renderBefore()?>
     	
@@ -43,7 +43,7 @@
                     <?=$this->renderCategoryOptions()?>
                 </select>
                 <?php
-                if(VF_Singleton::getInstance()->displayBrTag())
+                if(Elite_Vaf_Singleton::getInstance()->displayBrTag())
                 {
 					echo '<br />';
                 }

--- a/app/design/frontend/base/default/template/vf/vafgarage/GarageTest.php
+++ b/app/design/frontend/base/default/template/vf/vafgarage/GarageTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Elite_Vafgarage_design_frontend_GarageTest extends VF_TestCase
+class Elite_Vafgarage_design_frontend_GarageTest extends Elite_TestCase
 {
 
     function doSetUp()
@@ -18,7 +18,7 @@ class Elite_Vafgarage_design_frontend_GarageTest extends VF_TestCase
         	'year'=>''
         );
         $this->setRequestParams($requestParams);
-        VF_Singleton::getInstance()->storeFitInSession();
+        Elite_Vaf_Singleton::getInstance()->storeFitInSession();
         
         $block = new Elite_Vafgarage_design_garageTestSub;
         $output = $block->_toHtml();

--- a/app/design/frontend/base/default/template/vf/vaflinks/cms-list.phtml
+++ b/app/design/frontend/base/default/template/vf/vaflinks/cms-list.phtml
@@ -3,7 +3,7 @@
     <div class="content">
 
         <?php
-        $selection = VF_Singleton::getInstance()->vehicleSelection();
+        $selection = Elite_Vaf_Singleton::getInstance()->vehicleSelection();
         if ($selection) {
             ?>
             <strong>Your Selection</strong>

--- a/app/design/frontend/base/default/template/vf/vaflinks/list.phtml
+++ b/app/design/frontend/base/default/template/vf/vaflinks/list.phtml
@@ -3,7 +3,7 @@
     <div class="content"> 
 
         <?php
-        $selection = VF_Singleton::getInstance()->vehicleSelection();
+        $selection = Elite_Vaf_Singleton::getInstance()->vehicleSelection();
         if ($selection) {
             ?>
             <strong>Your Selection</strong>

--- a/app/design/frontend/base/default/template/vf/vafsitemap/vehiclesTest.php
+++ b/app/design/frontend/base/default/template/vf/vafsitemap/vehiclesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Elite_Vafsitemap_design_frontend_VehiclesTest extends VF_TestCase
+class Elite_Vafsitemap_design_frontend_VehiclesTest extends Elite_TestCase
 {
 
     function doSetUp()

--- a/app/design/frontend/base/default/template/vf/vaftire/search.phtml
+++ b/app/design/frontend/base/default/template/vf/vaftire/search.phtml
@@ -1,8 +1,8 @@
 <?php
-VF_Singleton::getInstance()->storeFitInSession();
+Elite_Vaf_Singleton::getInstance()->storeFitInSession();
 
 $finder = new Elite_Vaftire_Model_Finder();
-$flexibleSearch = VF_Singleton::getInstance()->flexibleSearch();
+$flexibleSearch = Elite_Vaf_Singleton::getInstance()->flexibleSearch();
 $flexibleSearch = new Elite_Vaftire_Model_FlexibleSearch($flexibleSearch);
 
 $helper = new Zend_View_Helper_FormSelect();

--- a/vf-documentation/design_guide/related_products.htm
+++ b/vf-documentation/design_guide/related_products.htm
@@ -1,6 +1,6 @@
 <?php
 $relatedProduct = new Elite_Vafrelated_Model_Catalog_Product($_product);
-$products = $relatedProduct->relatedProducts(VF_Singleton::getInstance()->getFit());
+$products = $relatedProduct->relatedProducts(Elite_Vaf_Singleton::getInstance()->getFit());
 echo '<h1>Related Vehicle Products</h1><ul>';
 foreach($products as $relatedProduct)
 {

--- a/vf-documentation/design_guide/selectedVehicleTest.php
+++ b/vf-documentation/design_guide/selectedVehicleTest.php
@@ -1,5 +1,5 @@
 <?php
-class selectedVehicleTest extends VF_TestCase
+class selectedVehicleTest extends Elite_TestCase
 {
     function testSnippet1_WhenNoVehicle()
     {
@@ -42,7 +42,7 @@ class selectedVehicleTest extends VF_TestCase
     function snippet1()
     {
         // Showing products for your: 2009 Honda Civic
-        $vehicleSelection = VF_Singleton::getInstance()->vehicleSelection();
+        $vehicleSelection = Elite_Vaf_Singleton::getInstance()->vehicleSelection();
         if( !$vehicleSelection->isEmpty() )
         {
             $vehicle = $vehicleSelection->getFirstVehicle();
@@ -54,7 +54,7 @@ class selectedVehicleTest extends VF_TestCase
     function snippet2()
     {
         // Showing products for your: 2009 Honda Civic
-        $vehicleSelection = VF_Singleton::getInstance()->vehicleSelection();
+        $vehicleSelection = Elite_Vaf_Singleton::getInstance()->vehicleSelection();
         if( !$vehicleSelection->isEmpty() )
         {
             $vehicle = $vehicleSelection->getFirstVehicle();

--- a/vf-documentation/design_guide/selected_vehicle.htm
+++ b/vf-documentation/design_guide/selected_vehicle.htm
@@ -30,7 +30,7 @@
 <p>The vehicle object returned by the getFit() method implements a PHP magic method, allowing it to be treated a string or an object. To display the name of a vehicle, simply echo the object.</p>
 <pre class="kodify php"> 
 // Showing products for your: 2009 Honda Civic
-$vehicleSelection = VF_Singleton::getInstance()->vehicleSelection();
+$vehicleSelection = Elite_Vaf_Singleton::getInstance()->vehicleSelection();
 if( !$vehicleSelection->isEmpty() )
 {
     $vehicle = $vehicleSelection->getFirstVehicle();
@@ -43,7 +43,7 @@ if( !$vehicleSelection->isEmpty() )
 <p>You can fetch each 'level' of the vehicle separately, and form your own custom formats.</p>
 <pre class="kodify php"> 
 // Showing products for your: 2009 Honda Civic
-$vehicleSelection = VF_Singleton::getInstance()->vehicleSelection();
+$vehicleSelection = Elite_Vaf_Singleton::getInstance()->vehicleSelection();
 if( !$vehicleSelection->isEmpty() )
 {
     $vehicle = $vehicleSelection->getFirstVehicle();

--- a/vf-documentation/modules/notes/product_template.htm
+++ b/vf-documentation/modules/notes/product_template.htm
@@ -30,7 +30,7 @@
  &lt;!-- begin fitment notes --&gt;
 &lt;?php
 $noteFinder = new Elite_Vafnote_Model_Finder();
-$vehicle = VF_Singleton::getInstance()->vehicleSelection()->getFirstVehicle();
+$vehicle = Elite_Vaf_Singleton::getInstance()->vehicleSelection()->getFirstVehicle();
 
 if( null == $vehicle )
 {

--- a/vf-documentation/seo.htm
+++ b/vf-documentation/seo.htm
@@ -92,11 +92,11 @@ globalRewrites = false
         With local rewriting, there a need to modify each template where you want to rewrite the titles, as shown:
         <pre class="kodify php">
 // when global rewrites are off & product fits current vehicle selection
-$product->setCurrentlySelectedFit( VF_Singleton::getInstance()->getFit() );
+$product->setCurrentlySelectedFit( Elite_Vaf_Singleton::getInstance()->getFit() );
 $product->getname(); //  Widget for Honda Civic 2002
 
 // when global rewrites are off & product does not fit current vehicle selection
-$product->setCurrentlySelectedFit( VF_Singleton::getInstance()->getFit() );
+$product->setCurrentlySelectedFit( Elite_Vaf_Singleton::getInstance()->getFit() );
 $product->getname();  // Widget
         </pre>
    </p>

--- a/vf-install.php
+++ b/vf-install.php
@@ -28,7 +28,7 @@ require_once( 'app/Mage.php' );
 Mage::app();
 require_once( 'app/code/local/Elite/Vaf/bootstrap.php' );
 
-$helper = VF_Singleton::getInstance();
+$helper = Elite_Vaf_Singleton::getInstance();
 ?>
 <form action="?" method="get">
 	<?php


### PR DESCRIPTION
- Configuration option is now available under modulestatus that have the options to enable/disable Vafwheel, Vaftire and Vafwheeladapter. This can save loading time if the modules are not required for some Magento E-commerce stores.
- Extended the VF_TestCase up to Elite_TestCase and moved needed Magento test case methods to Elite_TestCase where they belong.
- Extended VF_AbstractSingleton to Elite_Vaf_Singleton for the logic of finding if a module should be enabled/disabled based on the configuration option in config.ini/config.default.ini
- Elite_Vaf_Singleton extends the parent method flexibleSearch() and adds needed logic to call the needed Vafwheel/Vaftire/Vafwheeladapter modules to extend functionality of the enabled modules. If the module is enabled in the configuration but it cannot be found in the ELITE_PATH, an exception is thrown at runtime.
- Elite_Vaf_Singleton extends ensureDefaultSectionsExist and adds a call to ensure that the new configuration option called modulestatus exists as a section.
- Elite_TestCase over VF_TestCase for using the correct methods for the Magento Test Suite. 
- Bumped module versions to v2.1-build1 and modified composers branch-alias to 2.1.x-dev
